### PR TITLE
Feature: binary release assets

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,0 +1,29 @@
+name: Binary Release
+on:
+  release:
+    types: [published, prereleased]
+
+jobs:
+  release:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macos-10.15]
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: setup Go
+        uses: actions/setup-go@v2-beta
+        with:
+          go-version: '^1.14.0'
+      - name: compile & make tarball
+        run: make tarball
+      - name: upload release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./dgit.tar.gz
+          asset_name: dgit-${{ runner.os }}-x86_64.tar.gz
+          asset_content_type: application/x-gtar

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,7 +1,7 @@
 name: Binary Release
 on:
   release:
-    types: [published, prereleased]
+    types: [published]
 
 jobs:
   release:

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   release:
+    if: "!github.event.release.prerelease"
     runs-on: ubuntu-latest
     steps:
       - name: checkout formula
@@ -33,6 +34,7 @@ jobs:
           repository: quorumcontrol/homebrew-dgit
 
   build-bottle:
+    if: "!github.event.release.prerelease"
     runs-on: ${{ matrix.os }}
     needs: release
     strategy:
@@ -64,6 +66,7 @@ jobs:
           path: ${{ env.TARBALL }}
 
   update-formula:
+    if: "!github.event.release.prerelease"
     runs-on: ubuntu-latest
     needs: build-bottle
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.dylib
 decentragit-remote
 /dgit
+/dgit.tar.gz
 
 # Test binary, built with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,17 @@ $(FIRSTGOPATH)/bin/dgit: dgit
 $(FIRSTGOPATH)/bin/git-remote-dgit:
 	cp git-remote-dgit $(FIRSTGOPATH)/bin/
 
+dgit.tar.gz: dgit git-remote-dgit
+	tar -czvf dgit.tar.gz dgit git-remote-dgit
+
+tarball: dgit.tar.gz
+
 install: $(FIRSTGOPATH)/bin/dgit $(FIRSTGOPATH)/bin/git-remote-dgit
 
 test:
 	go test ./...
 
 clean:
-	rm dgit
+	rm -f dgit dgit.tar.gz
 
-.PHONY: all build install test clean
+.PHONY: all build tarball install test clean


### PR DESCRIPTION
I did this primarily for Linux, but it's pretty easy to have it build one for macOS too, so I went ahead and did that.

Also contains a fix for the homebrew formula & bottle update actions to not run on pre-releases (which I could have _sworn_ was how it was behaving before, but not now! 🤷‍♂).