### PR TITLE
dgit push github action

### DIFF
--- a/.github/workflows/dgit-push.yml
+++ b/.github/workflows/dgit-push.yml
@@ -1,0 +1,14 @@
+name: dgit push
+on:
+  push:
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Push to dgit
+      uses: quorumcontrol/dgit-github-action@master
+      env:
+        DGIT_PRIVATE_KEY: ${{ secrets.DGIT_PRIVATE_KEY }}
+        DGIT_LOG_LEVEL: debug

--- a/remotehelper/runner.go
+++ b/remotehelper/runner.go
@@ -243,9 +243,8 @@ func (r *Runner) Run(ctx context.Context, remoteName string, remoteUrl string) e
 		// Connect can be used for upload / receive pack
 		// case "connect":
 		// 	r.respond("fallback\n")
-		case "": // empty line separates commands, return new line to end command
-			r.respond("\n")
-			break
+		case "": // command stream terminated, return out
+			return nil
 		default:
 			return fmt.Errorf("Command '%s' not handled", command)
 		}

--- a/tupelo/repotree/repotree.go
+++ b/tupelo/repotree/repotree.go
@@ -3,6 +3,7 @@ package repotree
 import (
 	"context"
 	"crypto/ecdsa"
+	"strings"
 	"time"
 
 	"github.com/quorumcontrol/chaintree/chaintree"
@@ -25,7 +26,7 @@ type RepoTreeOptions struct {
 }
 
 func GenesisKey(repo string) (*ecdsa.PrivateKey, error) {
-	return consensus.PassPhraseKey([]byte(repo), repoSalt)
+	return consensus.PassPhraseKey([]byte(strings.ToLower(repo)), repoSalt)
 }
 
 func Did(repo string) (string, error) {

--- a/tupelo/repotree/repotree_test.go
+++ b/tupelo/repotree/repotree_test.go
@@ -1,0 +1,20 @@
+package repotree
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepoIsCaseInsenitive(t *testing.T) {
+
+	lower, err := Did("quorumcontrol/dgit-test")
+	require.Nil(t, err)
+	mixed, err := Did("quorumcontrol/DGIT-test")
+	require.Nil(t, err)
+	upper, err := Did("QUORUMCONTROL/DGIT-TEST")
+	require.Nil(t, err)
+
+	require.Equal(t, lower, mixed)
+	require.Equal(t, lower, upper)
+}


### PR DESCRIPTION
Adds https://github.com/quorumcontrol/dgit-github-action to this repo, sending all commits to `dgit` on push. A couple of related tweaks:

- Fixes the `exit 1` issue https://github.com/quorumcontrol/dgit/issues/5 - makes the build always red without it
- Ensures repo names are case insensitive. I had this logic inside the bash script of the github action, but decided that should be enforced for all dgit usage.