### PR TITLE
Add blank line at end of push

### DIFF
--- a/remotehelper/runner.go
+++ b/remotehelper/runner.go
@@ -199,6 +199,7 @@ func (r *Runner) Run(ctx context.Context, remoteName string, remoteUrl string) e
 			}
 
 			r.respond("ok %s\n", dst)
+			r.respond("\n")
 		case "fetch":
 			splitArgs := strings.Split(args, " ")
 			if len(splitArgs) != 2 {


### PR DESCRIPTION
This is a follow up to https://github.com/quorumcontrol/dgit/pull/25/commits/6cfe5dace0489d88f15f4f0a6f9d68733891cdbc - essentially the `\n` on the termination was actually closing out the push command. This adds back an explicit blank line to close out `push` resulting in a nice 0 exit code