### PR TITLE
Add version command & compile in a version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,17 @@
 gosources = $(shell find . -type f -name '*.go' -print)
 
 FIRSTGOPATH = $(firstword $(subst :, ,$(GOPATH)))
+HEAD_TAG := $(shell git tag --points-at HEAD)
+GIT_REV := $(shell git rev-parse --short HEAD)
+VERSION := $(or $(HEAD_TAG),$(GIT_REV))
+DEV_VERSION := $(shell git diff-index --quiet HEAD || echo "${VERSION}-dev")
+GOLDFLAGS += -X main.Version=$(or $(DEV_VERSION),$(VERSION))
+GOFLAGS = -ldflags "$(GOLDFLAGS)"
 
 all: build
 
 dgit: go.mod go.sum $(gosources)
-	go build -o dgit
+	go build -o dgit $(GOFLAGS) .
 
 build: dgit
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var Version string
+
+func init() {
+	rootCmd.AddCommand(versionCommand)
+}
+
+var versionCommand = &cobra.Command{
+	Use: "version",
+	Short: "Print dgit version",
+	Long: "Output dgit version to stdout",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("dgit version %s\n", Version)
+	},
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,9 @@ import (
 	"github.com/quorumcontrol/dgit/cmd"
 )
 
+var Version string
+
 func main() {
+	cmd.Version = Version
 	cmd.Execute()
 }


### PR DESCRIPTION
This adds a `dgit version` command that just outputs `dgit version [version string]`.

It also adds some logic to the Makefile to do one of the following when building the dgit binary:

1. If there is a git tag pointing at HEAD and the working directory is clean (untracked files are ignored here, for better or worse): version string will be the git tag (e.g. `v0.0.8-alpha`).
1. If there is a git tag pointing at HEAD but the working directory is NOT clean: version string will be the git tag pointing at HEAD with `-dev` appended to it (e.g. `v0.0.8-alpha-dev`).
1. If there is no git tag pointing at HEAD: the version string will be the short git SHA of the commit with `-dev` appended if the git working directory was not clean at build time (e.g. `1d781e1` for a clean build of git SHA `1d781e1` or `1d781e1-dev` for a dirty build of git SHA `1d781e1` plus local uncommitted changes).