### PR TITLE
Fix: generate error when keychain not unlockable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ replace (
 	github.com/golangci/gosec => github.com/golangci/gosec v0.0.0-20190211064107-66fb7fc33547
 	github.com/golangci/lint-1 => github.com/golangci/lint-1 v0.0.0-20190420132249-ee948d087217
 	github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
+	github.com/99designs/keyring => github.com/quorumcontrol/keyring v1.1.5-0.20200322160512-e16c51dc2ded
 	golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 	mvdan.cc/unparam => mvdan.cc/unparam v0.0.0-20190209190245-fbb59629db34
 )

--- a/go.sum
+++ b/go.sum
@@ -792,6 +792,8 @@ github.com/quorumcontrol/chaintree v1.0.2-0.20200124091942-25ceb93627b9 h1:7Rl0E
 github.com/quorumcontrol/chaintree v1.0.2-0.20200124091942-25ceb93627b9/go.mod h1:PHUsyPwSBW+m9cuE5isdhJ8ZnSkFRqD6qQo4Oxva2Yw=
 github.com/quorumcontrol/go-skynet v0.0.0-20200312164139-76fb137005c8 h1:X6zp2hKwK51po/w5z+XmKtR2sBijGD7tWHoIEobzpKw=
 github.com/quorumcontrol/go-skynet v0.0.0-20200312164139-76fb137005c8/go.mod h1:0uHjJYR8J4VnAixlHTaMyonV0F8pZc2qRNUR6gvDHYc=
+github.com/quorumcontrol/keyring v1.1.5-0.20200322160512-e16c51dc2ded h1:OaePmiZHxMW0IOUceYs0UXextL/XlRlLPLfuGEYYvA0=
+github.com/quorumcontrol/keyring v1.1.5-0.20200322160512-e16c51dc2ded/go.mod h1:657DQuMrBZRtuL/voxVyiyb6zpMehlm5vLB9Qwrv904=
 github.com/quorumcontrol/messages v1.1.1 h1:e90LvAM7YCZrFnXGM9H3pin+jjGqYPjW+YthBJkZHLc=
 github.com/quorumcontrol/messages v1.1.1/go.mod h1:PubykIzNsMO+CMecd7HDFKjBa4shVrPal8/GxM1+plc=
 github.com/quorumcontrol/messages/v2 v2.1.2/go.mod h1:on7qxEZYufdF6ZIyXFFWonyEmSdCuY+McIk2kLDiGwg=

--- a/keyring/keyring.go
+++ b/keyring/keyring.go
@@ -76,8 +76,6 @@ func FindPrivateKey(kr Keyring) (key *ecdsa.PrivateKey, err error) {
 }
 
 func FindOrCreatePrivateKey(kr Keyring) (key *ecdsa.PrivateKey, isNew bool, err error) {
-	keyName := "default"
-
 	privateKey, err := FindPrivateKey(kr)
 	if err == nil {
 		return privateKey, false, nil


### PR DESCRIPTION
This is half of the fix for #34. This stops silently acting like everything is OK and generates an error when the keychain isn't unlockable via the usual GUI dialog method (such as when you're connecting via SSH). The rest of the fix is to provide users a good way to use dgit on macOS over SSH.

With this in place, instead of appearing like everything worked when it didn't, `dgit init` says this:

```
$ dgit init
Error fetching key from keyring: error saving private key for dgit: User interaction is not allowed. (-25308)
```

I submitted a PR against keyring upstream here: https://github.com/99designs/keyring/pull/67

I also included a tiny opportunistic but unrelated fix I noticed in 41dcd28. Let me know if you'd like me to separate that out.