### PR TITLE
Emsmarten version setting in builds

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -55,6 +55,7 @@ jobs:
       - name: build bottle
         env:
           TARBALL: unknown
+          VERSION: ${{ github.event.release.tag_name }}
         run: |
           brew install --build-bottle quorumcontrol/dgit/dgit
           brew bottle --root-url=https://github.com/quorumcontrol/dgit/releases/download/${{ github.event.release.tag_name }} --no-rebuild quorumcontrol/dgit/dgit

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 gosources = $(shell find . -type f -name '*.go' -print)
 
 FIRSTGOPATH = $(firstword $(subst :, ,$(GOPATH)))
-HEAD_TAG := $(shell git tag --points-at HEAD)
-GIT_REV := $(shell git rev-parse --short HEAD)
-VERSION := $(or $(HEAD_TAG),$(GIT_REV))
-DEV_VERSION := $(shell git diff-index --quiet HEAD || echo "${VERSION}-dev")
-GOLDFLAGS += -X main.Version=$(or $(DEV_VERSION),$(VERSION))
+HEAD_TAG := $(shell if [ -d .git ]; then git tag --points-at HEAD; fi)
+GIT_REV := $(shell if [ -d .git ]; then git rev-parse --short HEAD; fi)
+GIT_VERSION := $(or $(HEAD_TAG),$(GIT_REV))
+DEV_VERSION := $(shell if [ -d .git ]; then git diff-index --quiet HEAD || echo "${GIT_VERSION}-dev"; fi)
+VERSION ?= $(or $(DEV_VERSION),$(GIT_VERSION))
+GOLDFLAGS += -X main.Version=$(VERSION)
 GOFLAGS = -ldflags "$(GOLDFLAGS)"
 
 all: build


### PR DESCRIPTION
Hopefully this will fix the `-dev` version string in homebrew builds (which for release tags do not happen in a git clone, just an untarred source tarball).