### PR TITLE
Add uninstall target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,14 @@ tarball: dgit.tar.gz
 
 install: $(FIRSTGOPATH)/bin/dgit $(FIRSTGOPATH)/bin/git-remote-dgit
 
+uninstall:
+	rm -f $(FIRSTGOPATH)/bin/dgit
+	rm -f $(FIRSTGOPATH)/bin/git-remote-dgit
+
 test:
 	go test ./...
 
 clean:
 	rm -f dgit dgit.tar.gz
 
-.PHONY: all build tarball install test clean
+.PHONY: all build tarball install uninstall test clean


### PR DESCRIPTION
Just a small developer convenience thing for when you're done testing a local build and want to go back to / test a release version. `make uninstall` deletes the `dgit` and `git-remote-dgit` files installed in your `$GOPATH/bin` dir so you can fall back on your `/usr/local/bin/` installation (depending on how your PATH is configured).