### PR TITLE
Feature: shared ownership

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ dgit: go.mod go.sum $(gosources)
 build: dgit
 
 $(FIRSTGOPATH)/bin/dgit: dgit
-	cp dgit $(FIRSTGOPATH)/bin/
+	cp $< $(FIRSTGOPATH)/bin/$<
 
-$(FIRSTGOPATH)/bin/git-remote-dgit:
-	cp git-remote-dgit $(FIRSTGOPATH)/bin/
+$(FIRSTGOPATH)/bin/git-remote-dgit: git-remote-dgit
+	cp $< $(FIRSTGOPATH)/bin/$<
 
 dgit.tar.gz: dgit git-remote-dgit
-	tar -czvf dgit.tar.gz dgit git-remote-dgit
+	tar -czvf dgit.tar.gz $^
 
 tarball: dgit.tar.gz
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ As an example:
 If you want to keep your decentralized, shareable git remote in sync with your GitHub repo adding
 a simple github rule as illustrated in [dgit-github-action](https://github.com/quorumcontrol/dgit-github-action) is all it takes.  Once completed your  dgit decentralized shareable remote will always be up to date and ready when you need it.<br>
 
+#### Collaborators
+
+You can manage your repo's team of collaborators with the `dgit team` command:
+
+* `dgit team add [collaborator usernames]`
+* `dgit team list`
+* `dgit team remove [usernames]`
+
+Anyone on the team will be allowed to push to the repo in the current directory.
+
 ### Built With
 
 * [Git](https://git-scm.com/)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ You can manage your repo's team of collaborators with the `dgit team` command:
 
 Anyone on the team will be allowed to push to the repo in the current directory.
 
+#### Configuration
+
+- Username can be set any of the following ways:
+  - `DGIT_USERNAME=[username]` env var
+  - `git config --global dgit.username [username]` sets it in `~/.gitconfig`
+  - `git config dgit.username [username]` sets it in `./.git/config`
+
 ### FAQ
 
 You can find answers to some of the most [frequently asked questions on the wiki](https://github.com/quorumcontrol/dgit/wiki/Frequently-Asked-Questions).

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/go-git/go-git/v5"
 	"github.com/spf13/cobra"
 
 	"github.com/quorumcontrol/dgit/initializer"
-	"github.com/quorumcontrol/dgit/msg"
 )
 
 func init() {
@@ -32,18 +30,7 @@ var initCommand = &cobra.Command{
 			os.Exit(1)
 		}
 
-		repo, err := openRepo(callingDir)
-		if err == git.ErrRepositoryNotExists {
-			msg.Fprint(os.Stderr, msg.RepoNotFoundInPath, map[string]interface{}{
-				"path": callingDir,
-				"cmd":  rootCmd.Name() + " " + cmd.Name(),
-			})
-			os.Exit(1)
-		}
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
-		}
+		repo := openRepo(cmd, callingDir)
 
 		client, err := newClient(ctx, repo)
 		if err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -59,7 +59,12 @@ var initCommand = &cobra.Command{
 		}
 		client.RegisterAsDefault()
 
-		err = initializer.Init(ctx, repo, args)
+		initOpts := &initializer.Options{
+			Repo:      repo,
+			Tupelo:    client.Tupelo,
+			NodeStore: client.Nodestore,
+		}
+		err = initializer.Init(ctx, initOpts, args)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/go-git/go-git/v5"
+	"github.com/spf13/cobra"
+
 	"github.com/quorumcontrol/dgit/initializer"
 	"github.com/quorumcontrol/dgit/msg"
-	"github.com/quorumcontrol/dgit/transport/dgit"
-	"github.com/spf13/cobra"
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/storage/filesystem"
 )
 
 func init() {
@@ -21,7 +20,7 @@ var initCommand = &cobra.Command{
 	Use:   "init",
 	Short: "Get rolling with dgit!",
 	// TODO: better explanation
-	Long: `Sets up an repo to leverage dgit.`,
+	Long: `Sets up a repo to leverage dgit.`,
 	Args: cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -29,35 +28,28 @@ var initCommand = &cobra.Command{
 
 		callingDir, err := os.Getwd()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting current workdir: %v", err)
+			fmt.Fprintln(os.Stderr, "error getting current workdir: %w", err)
 			os.Exit(1)
 		}
 
-		repo, err := git.PlainOpenWithOptions(callingDir, &git.PlainOpenOptions{
-			DetectDotGit: true,
-		})
-
+		repo, err := openRepo(callingDir)
 		if err == git.ErrRepositoryNotExists {
-			msg.Print(msg.RepoNotFoundInPath, map[string]interface{}{
+			msg.Fprint(os.Stderr, msg.RepoNotFoundInPath, map[string]interface{}{
 				"path": callingDir,
 				"cmd":  rootCmd.Name() + " " + cmd.Name(),
 			})
 			os.Exit(1)
 		}
-
 		if err != nil {
-			fmt.Printf("Error opening repo: %v", err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 
-		repoGitPath := repo.Storer.(*filesystem.Storage).Filesystem().Root()
-
-		client, err := dgit.NewClient(ctx, repoGitPath)
+		client, err := newClient(ctx, repo)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, fmt.Sprintf("error starting dgit client: %v", err))
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
-		client.RegisterAsDefault()
 
 		initOpts := &initializer.Options{
 			Repo:      repo,

--- a/cmd/remotehelper.go
+++ b/cmd/remotehelper.go
@@ -5,15 +5,15 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/go-git/go-billy/v5/osfs"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/cache"
+	"github.com/go-git/go-git/v5/storage/filesystem"
 	"github.com/quorumcontrol/dgit/remotehelper"
 	"github.com/quorumcontrol/dgit/storage/readonly"
 	"github.com/quorumcontrol/dgit/storage/split"
 	"github.com/quorumcontrol/dgit/transport/dgit"
 	"github.com/spf13/cobra"
-	"github.com/go-git/go-billy/v5/osfs"
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing/cache"
-	"github.com/go-git/go-git/v5/storage/filesystem"
 )
 
 func init() {

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/storage/filesystem"
+
+	"github.com/quorumcontrol/dgit/transport/dgit"
+)
+
+func openRepo(path string) (*dgit.Repo, error) {
+	gitRepo, err := git.PlainOpenWithOptions(path, &git.PlainOpenOptions{
+		DetectDotGit: true,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &dgit.Repo{Repository: gitRepo}, nil
+}
+
+func newClient(ctx context.Context, repo *dgit.Repo) (*dgit.Client, error) {
+	repoGitPath := repo.Storer.(*filesystem.Storage).Filesystem().Root()
+
+	client, err := dgit.NewClient(ctx, repoGitPath)
+	if err != nil {
+		return nil, fmt.Errorf("error starting dgit client: %w", err)
+	}
+	client.RegisterAsDefault()
+
+	return client, nil
+}

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -30,7 +30,7 @@ func openRepo(cmd *cobra.Command, path string) *dgit.Repo {
 		os.Exit(1)
 	}
 
-	return &dgit.Repo{Repository: gitRepo}
+	return dgit.NewRepo(gitRepo)
 }
 
 func newClient(ctx context.Context, repo *dgit.Repo) (*dgit.Client, error) {

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/spf13/cobra"
+
+	"github.com/quorumcontrol/dgit/msg"
+)
+
+func init() {
+	rootCmd.AddCommand(teamCommand)
+}
+
+var teamCommand = &cobra.Command{
+	Use:   "team (add [usernames] | list | remove [usernames])",
+	Short: "Manage your repo's team of collaborators",
+	Args: func(cmd *cobra.Command, args []string) error {
+		switch args[0] {
+		case "add", "remove":
+			if len(args) < 2 {
+				return fmt.Errorf("%s command requires one or more usernames to %s", args[0], args[0])
+			}
+			return nil
+		case "list":
+			if len(args) != 1 {
+				return fmt.Errorf("unexpected arguments after list command")
+			}
+			return nil
+		default:
+			return fmt.Errorf("unknown arguments to team command: %v", args)
+		}
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		callingDir, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "error getting current workdir: %w", err)
+			os.Exit(1)
+		}
+
+		repo, err := openRepo(callingDir)
+		if err == git.ErrRepositoryNotExists {
+			msg.Fprint(os.Stderr, msg.RepoNotFoundInPath, map[string]interface{}{
+				"path": callingDir,
+				"cmd":  rootCmd.Name() + " " + cmd.Name(),
+			})
+			os.Exit(1)
+		}
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		client, err := newClient(ctx, repo)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		subCmd := args[0]
+
+		switch subCmd {
+		case "add":
+			err := client.AddRepoCollaborator(ctx, repo, args[1:])
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+
+			fmt.Printf("Added:\n%s\n", strings.Join(args[1:], "\n"))
+		case "list":
+			collaborators, err := client.ListRepoCollaborators(ctx, repo)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+
+			fmt.Printf("Current collaborators:\n%s\n", strings.Join(collaborators, "\n"))
+		case "remove":
+			err := client.RemoveRepoCollaborator(ctx, repo, args[1:])
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+
+			fmt.Printf("Removed collaborators:\n%s\n", strings.Join(args[1:], "\n"))
+		}
+	},
+}

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -6,10 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/go-git/go-git/v5"
 	"github.com/spf13/cobra"
-
-	"github.com/quorumcontrol/dgit/msg"
 )
 
 func init() {

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -45,18 +45,7 @@ var teamCommand = &cobra.Command{
 			os.Exit(1)
 		}
 
-		repo, err := openRepo(callingDir)
-		if err == git.ErrRepositoryNotExists {
-			msg.Fprint(os.Stderr, msg.RepoNotFoundInPath, map[string]interface{}{
-				"path": callingDir,
-				"cmd":  rootCmd.Name() + " " + cmd.Name(),
-			})
-			os.Exit(1)
-		}
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
-		}
+		repo := openRepo(cmd, callingDir)
 
 		client, err := newClient(ctx, repo)
 		if err != nil {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -13,9 +13,9 @@ func init() {
 }
 
 var versionCommand = &cobra.Command{
-	Use: "version",
+	Use:   "version",
 	Short: "Print dgit version",
-	Long: "Output dgit version to stdout",
+	Long:  "Output dgit version to stdout",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("dgit version %s\n", Version)
 	},

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(whoAmICommand)
+}
+
+var whoAmICommand = &cobra.Command{
+	Use: "whoami",
+	Short: "Print out your username in the current repo",
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		callingDir, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "error getting current workdir: %w", err)
+			os.Exit(1)
+		}
+
+		repo := openRepo(cmd, callingDir)
+
+		username, err := repo.Username()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		fmt.Println(username)
+	},
+}

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -12,9 +12,9 @@ func init() {
 }
 
 var whoAmICommand = &cobra.Command{
-	Use: "whoami",
+	Use:   "whoami",
 	Short: "Print out your username in the current repo",
-	Args: cobra.NoArgs,
+	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		callingDir, err := os.Getwd()
 		if err != nil {

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -3,4 +3,5 @@ package constants
 const (
 	Protocol = "dgit"
 	DgitConfigSection = "dgit"
+    DgitRemote = "dgit"
 )

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -1,7 +1,7 @@
 package constants
 
 const (
-	Protocol = "dgit"
+	Protocol          = "dgit"
 	DgitConfigSection = "dgit"
-    DgitRemote = "dgit"
+	DgitRemote        = "dgit"
 )

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -2,4 +2,5 @@ package constants
 
 const (
 	Protocol = "dgit"
+	DgitConfigSection = "dgit"
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ replace (
 	github.com/99designs/keyring => github.com/quorumcontrol/keyring v1.1.5-0.20200324201224-62c57642bc6f
 	github.com/NebulousLabs/go-skynet => github.com/quorumcontrol/go-skynet v0.0.0-20200312164139-76fb137005c8
 	github.com/go-critic/go-critic => github.com/go-critic/go-critic v0.4.0
-	github.com/go-git/go-git/v5 => github.com/quorumcontrol/go-git/v5 v5.0.1-0.20200330190121-d2b81490dedb
+	github.com/go-git/go-git/v5 => github.com/quorumcontrol/go-git/v5 v5.0.1-0.20200406172056-231a188e4899
 	github.com/golangci/errcheck => github.com/golangci/errcheck v0.0.0-20181223084120-ef45e06d44b6
 	github.com/golangci/go-tools => github.com/golangci/go-tools v0.0.0-20190318060251-af6baa5dc196
 	github.com/golangci/gofmt => github.com/golangci/gofmt v0.0.0-20181222123516-0b8337e80d98

--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,16 @@ module github.com/quorumcontrol/dgit
 go 1.13
 
 replace (
+	github.com/99designs/keyring => github.com/quorumcontrol/keyring v1.1.5-0.20200324201224-62c57642bc6f
 	github.com/NebulousLabs/go-skynet => github.com/quorumcontrol/go-skynet v0.0.0-20200312164139-76fb137005c8
 	github.com/go-critic/go-critic => github.com/go-critic/go-critic v0.4.0
+	github.com/go-git/go-git/v5 => github.com/quorumcontrol/go-git/v5 v5.0.1-0.20200330190121-d2b81490dedb
 	github.com/golangci/errcheck => github.com/golangci/errcheck v0.0.0-20181223084120-ef45e06d44b6
 	github.com/golangci/go-tools => github.com/golangci/go-tools v0.0.0-20190318060251-af6baa5dc196
 	github.com/golangci/gofmt => github.com/golangci/gofmt v0.0.0-20181222123516-0b8337e80d98
 	github.com/golangci/gosec => github.com/golangci/gosec v0.0.0-20190211064107-66fb7fc33547
 	github.com/golangci/lint-1 => github.com/golangci/lint-1 v0.0.0-20190420132249-ee948d087217
 	github.com/keybase/go-keychain => github.com/quorumcontrol/go-keychain v0.0.0-20200324182052-9544b7eee399
-	github.com/99designs/keyring => github.com/quorumcontrol/keyring v1.1.5-0.20200324201224-62c57642bc6f
 	golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 	mvdan.cc/unparam => mvdan.cc/unparam v0.0.0-20190209190245-fbb59629db34
 )

--- a/go.sum
+++ b/go.sum
@@ -787,8 +787,8 @@ github.com/quorumcontrol/chaintree v0.9.4/go.mod h1:XZMtCWpLgWM6UVSRk431n+HIjJcn
 github.com/quorumcontrol/chaintree v1.0.2-0.20200123185821-453f01cdbbb9/go.mod h1:PHUsyPwSBW+m9cuE5isdhJ8ZnSkFRqD6qQo4Oxva2Yw=
 github.com/quorumcontrol/chaintree v1.0.2-0.20200124091942-25ceb93627b9 h1:7Rl0EE1sR8NdjwIw1er+018yDXXHbnvk03pGbEQPXOQ=
 github.com/quorumcontrol/chaintree v1.0.2-0.20200124091942-25ceb93627b9/go.mod h1:PHUsyPwSBW+m9cuE5isdhJ8ZnSkFRqD6qQo4Oxva2Yw=
-github.com/quorumcontrol/go-git/v5 v5.0.1-0.20200330190121-d2b81490dedb h1:/EPZMYH++tFnfF/csPYIy0BBQZbvHAa3FHN5GLILYGM=
-github.com/quorumcontrol/go-git/v5 v5.0.1-0.20200330190121-d2b81490dedb/go.mod h1:s58ZW7fdZEZcHqbLuDKI7EGsi928Evi5jNWua7t1LBY=
+github.com/quorumcontrol/go-git/v5 v5.0.1-0.20200406172056-231a188e4899 h1:tAVtM8piSRGCB6jRRBs91P/jaqUHgMTDdSCq0X1yuQ8=
+github.com/quorumcontrol/go-git/v5 v5.0.1-0.20200406172056-231a188e4899/go.mod h1:oYD8y9kWsGINPFJoLdaScGCN6dlKg23blmClfZwtUVA=
 github.com/quorumcontrol/go-keychain v0.0.0-20200324182052-9544b7eee399 h1:B9t4WAQXTsfRW6OlyKI3KK8vTAkZu5aIKtohJE1sDsY=
 github.com/quorumcontrol/go-keychain v0.0.0-20200324182052-9544b7eee399/go.mod h1:qKNyYzPILzVN3/4yQPjKdwuia7SMNzD+vazzCo1WffI=
 github.com/quorumcontrol/go-skynet v0.0.0-20200312164139-76fb137005c8 h1:X6zp2hKwK51po/w5z+XmKtR2sBijGD7tWHoIEobzpKw=

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,6 @@
 bazil.org/fuse v0.0.0-20180421153158-65cc252bf669/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
 cloud.google.com/go v0.26.0 h1:e0WKqKTd5BnrG8aKH3J3h+QvEIQtSUcf2n5UZ5ZgLtQ=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:/vQbFIOMbk2FiG/kXiLl8BRyzTWDw7gX/Hz7Dd5eDMs=
-github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:hN7oaIRCjzsZ2dE+yG5k+rsdt3qcwykqK6HVGcKwsw4=
-github.com/99designs/keyring v1.1.4 h1:x0g0zQ9bQKgNsLo0XSXAy1H8Q1RG/td+5OXJt+Ci8b8=
-github.com/99designs/keyring v1.1.4/go.mod h1:657DQuMrBZRtuL/voxVyiyb6zpMehlm5vLB9Qwrv904=
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9 h1:HD8gA2tkByhMAwYaFAX9w2l7vxvBQ5NMoxDrkhqhtn4=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
@@ -141,8 +137,6 @@ github.com/go-git/go-billy/v5 v5.0.0 h1:7NQHvd9FVid8VL4qVUMm8XifBK+2xCoZ2lSk0agR
 github.com/go-git/go-billy/v5 v5.0.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
 github.com/go-git/go-git-fixtures/v4 v4.0.1 h1:q+IFMfLx200Q3scvt2hN79JsEzy4AmBTp/pqnefH+Bc=
 github.com/go-git/go-git-fixtures/v4 v4.0.1/go.mod h1:m+ICp2rF3jDhFgEZ/8yziagdT1C+ZpZcrJjappBCDSw=
-github.com/go-git/go-git/v5 v5.0.1-0.20200319142726-f6305131a06b h1:NXE8OfhdKZdiH/yauQRmAovsTJd7+hn+5rg5l+vODUs=
-github.com/go-git/go-git/v5 v5.0.1-0.20200319142726-f6305131a06b/go.mod h1:oYD8y9kWsGINPFJoLdaScGCN6dlKg23blmClfZwtUVA=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-lintpack/lintpack v0.5.2/go.mod h1:NwZuYi2nUHho8XEIZ6SIxihrnPoqBTDqfpXvXAN0sXM=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
@@ -793,12 +787,12 @@ github.com/quorumcontrol/chaintree v0.9.4/go.mod h1:XZMtCWpLgWM6UVSRk431n+HIjJcn
 github.com/quorumcontrol/chaintree v1.0.2-0.20200123185821-453f01cdbbb9/go.mod h1:PHUsyPwSBW+m9cuE5isdhJ8ZnSkFRqD6qQo4Oxva2Yw=
 github.com/quorumcontrol/chaintree v1.0.2-0.20200124091942-25ceb93627b9 h1:7Rl0EE1sR8NdjwIw1er+018yDXXHbnvk03pGbEQPXOQ=
 github.com/quorumcontrol/chaintree v1.0.2-0.20200124091942-25ceb93627b9/go.mod h1:PHUsyPwSBW+m9cuE5isdhJ8ZnSkFRqD6qQo4Oxva2Yw=
+github.com/quorumcontrol/go-git/v5 v5.0.1-0.20200330190121-d2b81490dedb h1:/EPZMYH++tFnfF/csPYIy0BBQZbvHAa3FHN5GLILYGM=
+github.com/quorumcontrol/go-git/v5 v5.0.1-0.20200330190121-d2b81490dedb/go.mod h1:s58ZW7fdZEZcHqbLuDKI7EGsi928Evi5jNWua7t1LBY=
 github.com/quorumcontrol/go-keychain v0.0.0-20200324182052-9544b7eee399 h1:B9t4WAQXTsfRW6OlyKI3KK8vTAkZu5aIKtohJE1sDsY=
 github.com/quorumcontrol/go-keychain v0.0.0-20200324182052-9544b7eee399/go.mod h1:qKNyYzPILzVN3/4yQPjKdwuia7SMNzD+vazzCo1WffI=
 github.com/quorumcontrol/go-skynet v0.0.0-20200312164139-76fb137005c8 h1:X6zp2hKwK51po/w5z+XmKtR2sBijGD7tWHoIEobzpKw=
 github.com/quorumcontrol/go-skynet v0.0.0-20200312164139-76fb137005c8/go.mod h1:0uHjJYR8J4VnAixlHTaMyonV0F8pZc2qRNUR6gvDHYc=
-github.com/quorumcontrol/keyring v1.1.5-0.20200322160512-e16c51dc2ded h1:OaePmiZHxMW0IOUceYs0UXextL/XlRlLPLfuGEYYvA0=
-github.com/quorumcontrol/keyring v1.1.5-0.20200322160512-e16c51dc2ded/go.mod h1:657DQuMrBZRtuL/voxVyiyb6zpMehlm5vLB9Qwrv904=
 github.com/quorumcontrol/keyring v1.1.5-0.20200324201224-62c57642bc6f h1:ElmONO9ReBVAunXYNJyLDCRDh1qO1+tvyhOHt2eV3Ds=
 github.com/quorumcontrol/keyring v1.1.5-0.20200324201224-62c57642bc6f/go.mod h1:06MsWbyihr0379WTG9FluiAhoXmfSsqkoVDAf23KJUg=
 github.com/quorumcontrol/messages v1.1.1 h1:e90LvAM7YCZrFnXGM9H3pin+jjGqYPjW+YthBJkZHLc=

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -115,6 +115,13 @@ func (i *Initializer) findOrRequestUsername() (string, error) {
 		username = dgitConfig.Option("username")
 	}
 
+	// try looking up the GitHub username for the default
+	if username == "" {
+		if ghConfig := repoConfig.Raw.Section("github"); ghConfig != nil {
+			username = ghConfig.Option("user")
+		}
+	}
+
 	prompt := promptui.Prompt{
 		Label:     stripNewLines(msg.UsernamePrompt),
 		Templates: promptTemplates,

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -192,12 +192,10 @@ func (i *Initializer) getAuth() (transport.AuthMethod, error) {
 		ctx := context.Background()
 
 		opts := &usertree.Options{
-			Options: &namedtree.Options{
-				Name:      username,
-				Tupelo:    i.tupelo,
-				NodeStore: i.nodestore,
-				Owners:    []string{i.auth.String()},
-			},
+			Name:      username,
+			Tupelo:    i.tupelo,
+			NodeStore: i.nodestore,
+			Owners:    []string{i.auth.String()},
 		}
 		_, err := usertree.Create(ctx, opts)
 		if err != nil {

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -150,7 +150,7 @@ func (i *Initializer) findOrRequestUsername() (string, error) {
 
 	if username != "" && username != globalUsername {
 		log.Debugf("adding dgit.username to repo config")
-		newConfig := repoConfig.Merged.LocalConfig().AddOption(constants.DgitConfigSection, configformat.NoSubsection, "username", username)
+		newConfig := repoConfig.Merged.AddOption(configformat.LocalScope, constants.DgitConfigSection, configformat.NoSubsection, "username", username)
 		repoConfig.Merged.SetLocalConfig(newConfig)
 		err = repoConfig.Validate()
 		if err != nil {

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"regexp"
 	"strings"
 
@@ -297,9 +298,17 @@ func (i *Initializer) determineDgitEndpoint() (*transport.Endpoint, error) {
 		}
 	}
 
+	var suggestedRepoName string
+	username, _ := i.repo.Username()
+	cwd, _ := os.Getwd()
+	if username != "" && cwd != "" {
+		suggestedRepoName = username + "/" + path.Base(cwd)
+	}
+
 	prompt := promptui.Prompt{
 		Label:     stripNewLines(msg.PromptRepoName),
 		Templates: promptTemplates,
+		Default:   suggestedRepoName,
 		Stdin:     i.stdin,
 		Stdout:    i.stdout,
 		Validate: func(input string) error {

--- a/keyring/keyring.go
+++ b/keyring/keyring.go
@@ -29,9 +29,6 @@ var KeyringPrettyNames = map[string]string{
 	"*keyring.passKeyring":    "pass",
 }
 
-// TODO: scope private key by usernames
-var keyName = "default"
-
 var ErrKeyNotFound = keyringlib.ErrKeyNotFound
 
 func NewDefault() (Keyring, error) {
@@ -56,7 +53,7 @@ func Name(kr Keyring) string {
 	return name
 }
 
-func FindPrivateKey(kr Keyring) (key *ecdsa.PrivateKey, err error) {
+func FindPrivateKey(kr Keyring, keyName string) (key *ecdsa.PrivateKey, err error) {
 	privateKeyItem, err := kr.Get(keyName)
 	if err == keyringlib.ErrKeyNotFound {
 		return nil, ErrKeyNotFound
@@ -75,8 +72,8 @@ func FindPrivateKey(kr Keyring) (key *ecdsa.PrivateKey, err error) {
 	return key, nil
 }
 
-func FindOrCreatePrivateKey(kr Keyring) (key *ecdsa.PrivateKey, isNew bool, err error) {
-	privateKey, err := FindPrivateKey(kr)
+func FindOrCreatePrivateKey(kr Keyring, keyName string) (key *ecdsa.PrivateKey, isNew bool, err error) {
+	privateKey, err := FindPrivateKey(kr, keyName)
 	if err == nil {
 		return privateKey, false, nil
 	}

--- a/keyring/keyring.go
+++ b/keyring/keyring.go
@@ -7,7 +7,10 @@ import (
 	keyringlib "github.com/99designs/keyring"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
+	logging "github.com/ipfs/go-log"
 )
+
+var log = logging.Logger("dgit.keyring")
 
 type Keyring interface {
 	keyringlib.Keyring
@@ -53,10 +56,38 @@ func Name(kr Keyring) string {
 	return name
 }
 
+func migrateOldDefaultKey(kr Keyring, keyName string) (*keyringlib.Item, error) {
+	oldDefault, err := kr.Get("default")
+	if err == keyringlib.ErrKeyNotFound {
+		log.Debugf("no dgit.default key found")
+		return nil, ErrKeyNotFound
+	}
+
+	if err == nil {
+		log.Debugf("migrating old dgit.default key to dgit.%s", keyName)
+		oldDefault.Key = keyName
+		oldDefault.Label = "dgit." + keyName
+		err = kr.Set(oldDefault)
+		if err != nil {
+			log.Errorf("error migrating dgit.default key: %v", err)
+			return nil, err
+		}
+		_ = kr.Remove("default")
+	}
+
+	return &oldDefault, err
+}
+
 func FindPrivateKey(kr Keyring, keyName string) (key *ecdsa.PrivateKey, err error) {
+	log.Debugf("finding private key %s", keyName)
 	privateKeyItem, err := kr.Get(keyName)
 	if err == keyringlib.ErrKeyNotFound {
-		return nil, ErrKeyNotFound
+		log.Debugf("private key %s not found; attempting to migrate old dgit.default key", keyName)
+		migratedItem, err := migrateOldDefaultKey(kr, keyName)
+		if err != nil {
+			return nil, err
+		}
+		privateKeyItem = *migratedItem
 	}
 
 	privateKeyBytes, err := hexutil.Decode(string(privateKeyItem.Data))

--- a/keyring/keyring.go
+++ b/keyring/keyring.go
@@ -72,7 +72,10 @@ func migrateOldDefaultKey(kr Keyring, keyName string) (*keyringlib.Item, error) 
 			log.Errorf("error migrating dgit.default key: %v", err)
 			return nil, err
 		}
-		_ = kr.Remove("default")
+		remErr := kr.Remove("default")
+		if remErr != nil {
+			log.Warnf("error removing old dgit.default key: %v", remErr)
+		}
 	}
 
 	return &oldDefault, err

--- a/msg/messages.go
+++ b/msg/messages.go
@@ -5,8 +5,7 @@ Welcome to dgit!
 
 A private key has been generated for you and is stored in {{.keyringProvider}}.
 
-Below is your dgit public address, share this with others so they can grant you write access to dgit repos.
-{{.userAddress}}
+Your dgit username is {{.username}}. Others can grant you access to their repos by running: dgit team add {{.username}}.
 `
 
 var AddDgitToRemote = `
@@ -76,4 +75,8 @@ No .git directory found in {{.path}}.
 Please change directories to a git repo and run '{{.cmd}}' again.
 
 If you would like to create a new repo, use 'git init' normally and run '{{.cmd}}' again.
+`
+
+var UsernamePrompt = `
+What dgit username would you like to use?
 `

--- a/remotehelper/runner.go
+++ b/remotehelper/runner.go
@@ -305,8 +305,6 @@ func (r *Runner) auth() (transport.AuthMethod, error) {
 		username = dgitConfig.Option("username")
 	}
 
-	// TODO: What other username fallbacks should we have?
-
 	if username == "" {
 		log.Fatal("No dgit username configured. Run `git config --global dgit.username your-username`.")
 	}

--- a/remotehelper/runner.go
+++ b/remotehelper/runner.go
@@ -253,8 +253,6 @@ func (r *Runner) Run(ctx context.Context, remoteName string, remoteUrl string) e
 			return fmt.Errorf("Command '%s' not handled", command)
 		}
 	}
-
-	return nil
 }
 
 func (r *Runner) respond(format string, a ...interface{}) (n int, err error) {
@@ -303,6 +301,11 @@ func (r *Runner) auth() (transport.AuthMethod, error) {
 	var username string
 	if dgitConfig != nil {
 		username = dgitConfig.Option("username")
+	}
+
+	envUsername := os.Getenv("DGIT_USERNAME")
+	if envUsername != "" {
+		username = envUsername
 	}
 
 	if username == "" {

--- a/remotehelper/runner.go
+++ b/remotehelper/runner.go
@@ -298,7 +298,7 @@ func (r *Runner) auth() (transport.AuthMethod, error) {
 		return nil, err
 	}
 
-	dgitConfig := repoConfig.Raw.Section(constants.DgitConfigSection)
+	dgitConfig := repoConfig.Merged.Section(constants.DgitConfigSection)
 
 	var username string
 	if dgitConfig != nil {

--- a/remotehelper/runner_test.go
+++ b/remotehelper/runner_test.go
@@ -61,7 +61,7 @@ func TestRunnerIntegration(t *testing.T) {
 	require.NotNil(t, userMsgReader)
 
 	kr := keyring.NewMemory()
-	_, isNew, err := keyring.FindOrCreatePrivateKey(kr)
+	_, isNew, err := keyring.FindOrCreatePrivateKey(kr, "test")
 	require.Nil(t, err)
 	require.True(t, isNew)
 

--- a/remotehelper/runner_test.go
+++ b/remotehelper/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"os"
 	"sync"
 	"testing"
 
@@ -26,6 +27,11 @@ func TestRunnerIntegration(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	err := os.Setenv("DGIT_OBJ_STORAGE", "chaintree")
+	require.Nil(t, err)
+	err = os.Setenv("DGIT_USERNAME", "testymctestface")
+	require.Nil(t, err)
 
 	client, err := dgit.NewLocalClient(ctx)
 	require.Nil(t, err)
@@ -61,7 +67,7 @@ func TestRunnerIntegration(t *testing.T) {
 	require.NotNil(t, userMsgReader)
 
 	kr := keyring.NewMemory()
-	_, isNew, err := keyring.FindOrCreatePrivateKey(kr, "test")
+	_, isNew, err := keyring.FindOrCreatePrivateKey(kr, "testymctestface")
 	require.Nil(t, err)
 	require.True(t, isNew)
 

--- a/storage/chaintree/reference.go
+++ b/storage/chaintree/reference.go
@@ -5,12 +5,12 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/quorumcontrol/chaintree/chaintree"
-	"github.com/quorumcontrol/messages/v2/build/go/transactions"
-	"go.uber.org/zap"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/storer"
 	gitstorage "github.com/go-git/go-git/v5/storage"
+	"github.com/quorumcontrol/chaintree/chaintree"
+	"github.com/quorumcontrol/messages/v2/build/go/transactions"
+	"go.uber.org/zap"
 
 	"github.com/quorumcontrol/dgit/storage"
 )

--- a/storage/object_test.go
+++ b/storage/object_test.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -18,8 +17,6 @@ func TestZlibBufferForObject(t *testing.T) {
 
 	buf, err := ZlibBufferForObject(o)
 	require.Nil(t, err)
-
-	fmt.Printf("%v", buf.Bytes())
 
 	require.Equal(t, buf.Bytes(), []byte{120, 156, 74, 202, 201, 79, 82, 48, 52, 97, 240, 72, 205, 201, 201, 215, 81, 8, 207, 47, 202, 73, 81, 228, 2, 4, 0, 0, 255, 255, 78, 21, 6, 152})
 }

--- a/transport/dgit/client.go
+++ b/transport/dgit/client.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/quorumcontrol/dgit/constants"
 	"github.com/quorumcontrol/dgit/tupelo/clientbuilder"
-	"github.com/quorumcontrol/dgit/tupelo/namedtree"
 	"github.com/quorumcontrol/dgit/tupelo/repotree"
 )
 
@@ -73,12 +72,10 @@ func (c *Client) CreateRepoTree(ctx context.Context, endpoint *transport.Endpoin
 		return nil, fmt.Errorf("unable to cast %T to PrivateKeyAuth", auth)
 	}
 	return repotree.Create(ctx, &repotree.Options{
-		Options: &namedtree.Options{
-			Name:      endpoint.Host + endpoint.Path,
-			Tupelo:    c.Tupelo,
-			NodeStore: c.Nodestore,
-			Owners:    []string{auth.String()},
-		},
+		Name:      endpoint.Host + endpoint.Path,
+		Tupelo:    c.Tupelo,
+		NodeStore: c.Nodestore,
+		Owners:    []string{auth.String()},
 	}, pkAuth.Key())
 }
 

--- a/transport/dgit/client.go
+++ b/transport/dgit/client.go
@@ -65,6 +65,13 @@ func NewLocalClient(ctx context.Context) (*Client, error) {
 
 // FIXME: this probably shouldn't be here
 func (c *Client) CreateRepoTree(ctx context.Context, endpoint *transport.Endpoint, auth transport.AuthMethod) (*repotree.RepoTree, error) {
+	var (
+		pkAuth *PrivateKeyAuth
+		ok     bool
+	)
+	if pkAuth, ok = auth.(*PrivateKeyAuth); !ok {
+		return nil, fmt.Errorf("unable to cast %T to PrivateKeyAuth", auth)
+	}
 	return repotree.Create(ctx, &repotree.Options{
 		Options: &namedtree.Options{
 			Name:      endpoint.Host + endpoint.Path,
@@ -72,7 +79,7 @@ func (c *Client) CreateRepoTree(ctx context.Context, endpoint *transport.Endpoin
 			NodeStore: c.Nodestore,
 			Owners:    []string{auth.String()},
 		},
-	})
+	}, pkAuth.Key())
 }
 
 func (c *Client) FindRepoTree(ctx context.Context, repo string) (*repotree.RepoTree, error) {

--- a/transport/dgit/loader.go
+++ b/transport/dgit/loader.go
@@ -5,11 +5,11 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 
-	"github.com/quorumcontrol/chaintree/nodestore"
-	tupelo "github.com/quorumcontrol/tupelo-go-sdk/gossip/client"
 	"github.com/go-git/go-git/v5/plumbing/storer"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/server"
+	"github.com/quorumcontrol/chaintree/nodestore"
+	tupelo "github.com/quorumcontrol/tupelo-go-sdk/gossip/client"
 
 	"github.com/quorumcontrol/dgit/storage"
 	"github.com/quorumcontrol/dgit/storage/chaintree"

--- a/transport/dgit/loader.go
+++ b/transport/dgit/loader.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/quorumcontrol/dgit/storage"
 	"github.com/quorumcontrol/dgit/storage/chaintree"
+	"github.com/quorumcontrol/dgit/tupelo/namedtree"
 	"github.com/quorumcontrol/dgit/tupelo/repotree"
 )
 
@@ -38,7 +39,7 @@ func NewChainTreeLoader(ctx context.Context, tupelo *tupelo.Client, nodestore no
 }
 
 func (l *ChainTreeLoader) Load(ep *transport.Endpoint) (storer.Storer, error) {
-	chainTree, err := repotree.Find(l.ctx, ep.Host+ep.Path, l.tupelo)
+	repoTree, err := repotree.Find(l.ctx, ep.Host+ep.Path, l.tupelo)
 
 	var privateKey *ecdsa.PrivateKey
 
@@ -51,7 +52,7 @@ func (l *ChainTreeLoader) Load(ep *transport.Endpoint) (storer.Storer, error) {
 		return nil, fmt.Errorf("Unsupported auth type %T", l.auth)
 	}
 
-	if err == repotree.ErrNotFound {
+	if err == namedtree.ErrNotFound {
 		return nil, transport.ErrRepositoryNotFound
 	}
 
@@ -62,7 +63,7 @@ func (l *ChainTreeLoader) Load(ep *transport.Endpoint) (storer.Storer, error) {
 	return chaintree.NewStorage(&storage.Config{
 		Ctx:        l.ctx,
 		Tupelo:     l.tupelo,
-		ChainTree:  chainTree,
+		ChainTree:  repoTree.ChainTree,
 		PrivateKey: privateKey,
 	})
 }

--- a/transport/dgit/repo.go
+++ b/transport/dgit/repo.go
@@ -3,6 +3,7 @@ package dgit
 import (
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -132,6 +133,11 @@ func (r *Repo) Username() (string, error) {
 	}
 
 	username := dgitConfig.Option("username")
+
+	envUsername := os.Getenv("DGIT_USERNAME")
+	if envUsername != "" {
+		username = envUsername
+	}
 
 	if username == "" {
 		return "", fmt.Errorf("no dgit username found; run `git config --global dgit.username your-username`")

--- a/transport/dgit/repo.go
+++ b/transport/dgit/repo.go
@@ -22,7 +22,7 @@ type Repo struct {
 	auth     transport.AuthMethod
 }
 
-func New(gitRepo *git.Repository) *Repo {
+func NewRepo(gitRepo *git.Repository) *Repo {
 	return &Repo{Repository: gitRepo}
 }
 

--- a/transport/dgit/repo.go
+++ b/transport/dgit/repo.go
@@ -1,0 +1,166 @@
+package dgit
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+
+	"github.com/quorumcontrol/dgit/constants"
+	"github.com/quorumcontrol/dgit/keyring"
+)
+
+var ErrEndpointNotFound = errors.New("endpoint not found")
+
+type Repo struct {
+	*git.Repository
+
+	endpoint *transport.Endpoint
+	auth     transport.AuthMethod
+}
+
+func New(gitRepo *git.Repository) *Repo {
+	return &Repo{Repository: gitRepo}
+}
+
+func (r *Repo) Endpoint() (*transport.Endpoint, error) {
+	if r.endpoint != nil {
+		return r.endpoint, nil
+	}
+
+	remotes, err := r.Repository.Remotes()
+	if err != nil {
+		return nil, err
+	}
+
+	// get remotes sorted by dgit, then origin, then rest
+	sort.Slice(remotes, func(i, j int) bool {
+		iName := remotes[i].Config().Name
+		jName := remotes[j].Config().Name
+		if iName == "origin" && jName == constants.DgitRemote {
+			return false
+		}
+		return iName == "origin" || iName == constants.DgitRemote
+	})
+
+	dgitUrls := []string{}
+
+	for _, remote := range remotes {
+		for _, url := range remote.Config().URLs {
+			if strings.HasPrefix(url, constants.Protocol) {
+				dgitUrls = append(dgitUrls, url)
+			}
+		}
+	}
+
+	if len(dgitUrls) > 0 {
+		ep, err := transport.NewEndpoint(dgitUrls[0])
+		if err != nil {
+			return nil, err
+		}
+
+		r.endpoint = ep
+
+		return ep, nil
+	}
+
+	return nil, ErrEndpointNotFound
+}
+
+func (r *Repo) MustEndpoint() *transport.Endpoint {
+	ep, err := r.Endpoint()
+	if err != nil {
+		panic(err)
+	}
+
+	return ep
+}
+
+func (r *Repo) SetEndpoint(endpoint *transport.Endpoint) {
+	r.endpoint = endpoint
+}
+
+func (r *Repo) Name() (string, error) {
+	ep, err := r.Endpoint()
+	if err != nil {
+		return "", err
+	}
+
+	return ep.Host + ep.Path, nil
+}
+
+func (r *Repo) MustName() string {
+	name, err := r.Name()
+	if err != nil {
+		panic(err)
+	}
+
+	return name
+}
+
+func (r *Repo) URL() (string, error) {
+	ep, err := r.Endpoint()
+	if err != nil {
+		return "", err
+	}
+
+	return ep.String(), nil
+}
+
+func (r *Repo) MustURL() string {
+	url, err := r.URL()
+	if err != nil {
+		panic(err)
+	}
+
+	return url
+}
+
+func (r *Repo) Username() (string, error) {
+	repoConfig, err := r.Config()
+	if err != nil {
+		return "", err
+	}
+
+	dgitConfig := repoConfig.Raw.Section(constants.DgitConfigSection)
+
+	if dgitConfig == nil {
+		return "", fmt.Errorf("no dgit configuration found; run `git config --global dgit.username your-username`")
+	}
+
+	username := dgitConfig.Option("username")
+
+	if username == "" {
+		return "", fmt.Errorf("no dgit username found; run `git config --global dgit.username your-username`")
+	}
+
+	return username, nil
+}
+
+func (r *Repo) Auth() (transport.AuthMethod, error) {
+	if r.auth != nil {
+		return r.auth, nil
+	}
+
+	kr, err := keyring.NewDefault()
+	if err != nil {
+		return nil, err
+	}
+
+	username, err := r.Username()
+	if err != nil {
+		return nil, err
+	}
+
+	privateKey, err := keyring.FindPrivateKey(kr, username)
+	if err != nil {
+		return nil, err
+	}
+
+	r.auth = NewPrivateKeyAuth(privateKey)
+
+	return r.auth, nil
+}

--- a/transport/dgit/repo.go
+++ b/transport/dgit/repo.go
@@ -125,7 +125,7 @@ func (r *Repo) Username() (string, error) {
 		return "", err
 	}
 
-	dgitConfig := repoConfig.Raw.Section(constants.DgitConfigSection)
+	dgitConfig := repoConfig.Merged.Section(constants.DgitConfigSection)
 
 	if dgitConfig == nil {
 		return "", fmt.Errorf("no dgit configuration found; run `git config --global dgit.username your-username`")

--- a/tupelo/namedtree/namedtree.go
+++ b/tupelo/namedtree/namedtree.go
@@ -1,0 +1,142 @@
+package namedtree
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/quorumcontrol/chaintree/chaintree"
+	"github.com/quorumcontrol/chaintree/nodestore"
+	"github.com/quorumcontrol/messages/v2/build/go/transactions"
+	"github.com/quorumcontrol/tupelo-go-sdk/consensus"
+	tupelo "github.com/quorumcontrol/tupelo-go-sdk/gossip/client"
+)
+
+const DefaultObjectStorageType = "siaskynet"
+
+var ErrNotFound = tupelo.ErrNotFound
+
+type Generator struct {
+	Namespace string
+	Client    *tupelo.Client
+}
+
+type NamedTree struct {
+	Name      string
+	ChainTree *consensus.SignedChainTree
+
+	genesisKey *ecdsa.PrivateKey
+	client     *tupelo.Client
+	nodeStore  nodestore.DagStore
+	owners     []string
+}
+
+type Options struct {
+	Name              string
+	ObjectStorageType string
+	Client            *tupelo.Client
+	NodeStore         nodestore.DagStore
+	Owners            []string
+}
+
+func (g *Generator) GenesisKey(name string) (*ecdsa.PrivateKey, error) {
+	return consensus.PassPhraseKey([]byte(name), []byte(g.Namespace))
+}
+
+func (g *Generator) New(ctx context.Context, opts *Options) (*NamedTree, error) {
+	gKey, err := g.GenesisKey(opts.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	chainTree, err := consensus.NewSignedChainTree(ctx, gKey.PublicKey, opts.NodeStore)
+	if err != nil {
+		return nil, err
+	}
+
+	setOwnershipTxn, err := chaintree.NewSetOwnershipTransaction(opts.Owners)
+	if err != nil {
+		return nil, err
+	}
+
+	repoTxn, err := chaintree.NewSetDataTransaction("dgit/repo", opts.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	if storage, found := os.LookupEnv("DGIT_OBJ_STORAGE"); found {
+		opts.ObjectStorageType = storage
+	}
+	if opts.ObjectStorageType == "" {
+		opts.ObjectStorageType = DefaultObjectStorageType
+	}
+	config := map[string]map[string]string{"objectStorage": {"type": opts.ObjectStorageType}}
+	configTxn, err := chaintree.NewSetDataTransaction("dgit/config", config)
+	if err != nil {
+		return nil, err
+	}
+
+	creationTimestampTxn, err := chaintree.NewSetDataTransaction("dgit/createdAt", time.Now().Unix())
+	if err != nil {
+		return nil, err
+	}
+
+	txns := []*transactions.Transaction{setOwnershipTxn, repoTxn, configTxn, creationTimestampTxn}
+
+	_, err = opts.Client.PlayTransactions(ctx, chainTree, gKey, txns)
+	if err != nil {
+		return nil, err
+	}
+
+	return &NamedTree{
+		Name:       opts.Name,
+		ChainTree:  chainTree,
+		genesisKey: gKey,
+		client:     opts.Client,
+		nodeStore:  opts.NodeStore,
+		owners:     opts.Owners,
+	}, nil
+}
+
+// Did lower-cases the name arg first to ensure that chaintree
+// names are case insensitive. If we ever want case sensitivity,
+// consider adding a bool flag to the Generator or adding a new
+// fun.
+func (g *Generator) Did(name string) (string, error) {
+	gKey, err := g.GenesisKey(strings.ToLower(name))
+	if err != nil {
+		return "", err
+	}
+
+	return consensus.EcdsaPubkeyToDid(gKey.PublicKey), nil
+}
+
+func (g *Generator) Find(ctx context.Context, name string) (*NamedTree, error) {
+	did, err := g.Did(name)
+	if err != nil {
+		return nil, err
+	}
+
+	chainTree, err := g.Client.GetLatest(ctx, did)
+	if err == tupelo.ErrNotFound {
+		return nil, ErrNotFound
+	}
+
+	gKey, err := g.GenesisKey(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &NamedTree{
+		Name:       name,
+		ChainTree:  chainTree,
+		genesisKey: gKey,
+		client:     g.Client,
+	}, nil
+}
+
+func (t *NamedTree) Did() string {
+	return consensus.EcdsaPubkeyToDid(t.genesisKey.PublicKey)
+}

--- a/tupelo/repotree/repotree.go
+++ b/tupelo/repotree/repotree.go
@@ -2,13 +2,25 @@ package repotree
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"os"
+	"strings"
 
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/quorumcontrol/chaintree/chaintree"
+	"github.com/quorumcontrol/messages/v2/build/go/transactions"
 	tupelo "github.com/quorumcontrol/tupelo-go-sdk/gossip/client"
 
 	"github.com/quorumcontrol/dgit/tupelo/namedtree"
 )
 
-const repoSalt = "decentragit-0.0.0-alpha"
+const (
+	repoSalt                 = "decentragit-0.0.0-alpha"
+	DefaultObjectStorageType = "siaskynet"
+)
+
+var collabPath = []string{"tree", "data", "dgit", "team"}
 
 var namedTreeGen *namedtree.Generator
 
@@ -20,16 +32,177 @@ type Options struct {
 	*namedtree.Options
 }
 
-func Find(ctx context.Context, repo string, client *tupelo.Client) (*namedtree.NamedTree, error) {
-	namedTreeGen.Client = client
-	return namedTreeGen.Find(ctx, repo)
+type RepoTree struct {
+	*namedtree.NamedTree
 }
 
-func Create(ctx context.Context, opts *Options) (*namedtree.NamedTree, error) {
+func Find(ctx context.Context, repo string, client *tupelo.Client) (*RepoTree, error) {
+	namedTreeGen.Client = client
+	nt, err := namedTreeGen.Find(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+	return &RepoTree{nt}, nil
+}
+
+func Create(ctx context.Context, opts *Options) (*RepoTree, error) {
 	namedTree, err := namedTreeGen.New(ctx, opts.Options)
 	if err != nil {
 		return nil, err
 	}
 
-	return namedTree, nil
+	repoTxn, err := chaintree.NewSetDataTransaction("dgit/repo", opts.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	if storage, found := os.LookupEnv("DGIT_OBJ_STORAGE"); found {
+		opts.ObjectStorageType = storage
+	}
+	if opts.ObjectStorageType == "" {
+		opts.ObjectStorageType = DefaultObjectStorageType
+	}
+	config := map[string]map[string]string{"objectStorage": {"type": opts.ObjectStorageType}}
+	configTxn, err := chaintree.NewSetDataTransaction("dgit/config", config)
+	if err != nil {
+		return nil, err
+	}
+
+	teamTxn, err := createCollabPathTxn()
+	if err != nil {
+		return nil, err
+	}
+
+	txns := []*transactions.Transaction{repoTxn, configTxn, teamTxn}
+
+	ownerKey, err := crypto.ToECDSA([]byte(opts.Owners[0]))
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = opts.Tupelo.PlayTransactions(ctx, namedTree.ChainTree, ownerKey, txns)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RepoTree{namedTree}, nil
+}
+
+// updateCollaborators takes an ownerKey for the update transaction (if needed)
+// and a newCollaborators func that takes the current set and returns the entire set
+// of new collaborators (it is expected to close over the incoming set).
+func (rt *RepoTree) updateCollaborators(ctx context.Context, ownerKey *ecdsa.PrivateKey, newCollaborators func([]string) []string) error {
+	currentCollaborators, err := rt.ListCollaborators(ctx, ownerKey)
+	if err != nil {
+		return err
+	}
+
+	updated := newCollaborators(currentCollaborators)
+
+	if len(updated) == len(currentCollaborators) {
+		return nil
+	}
+
+	txn, err := chaintree.NewSetDataTransaction("dgit/team", updated)
+	if err != nil {
+		return err
+	}
+
+	_, err = rt.Tupelo.PlayTransactions(ctx, rt.ChainTree, ownerKey, []*transactions.Transaction{txn})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (rt *RepoTree) AddCollaborators(ctx context.Context, collaborators []string, ownerKey *ecdsa.PrivateKey) error {
+	return rt.updateCollaborators(ctx, ownerKey, func(current []string) []string {
+		var newCollaborators []string
+
+		for _, c := range collaborators {
+			var exists bool
+			for _, cc := range current {
+				if c == cc {
+					exists = true
+					break
+				}
+			}
+			if !exists {
+				newCollaborators = append(current, c)
+			}
+		}
+
+		return newCollaborators
+	})
+}
+
+func createCollabPathTxn() (*transactions.Transaction, error) {
+	return chaintree.NewSetDataTransaction(strings.Join(collabPath[2:], "/"), []string{})
+}
+
+func (rt *RepoTree) createCollabPath(ctx context.Context, ownerKey *ecdsa.PrivateKey) error {
+	txn, err := createCollabPathTxn()
+	if err != nil {
+		return err
+	}
+
+	_, err = rt.Tupelo.PlayTransactions(ctx, rt.ChainTree, ownerKey, []*transactions.Transaction{txn})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (rt *RepoTree) ListCollaborators(ctx context.Context, ownerKey *ecdsa.PrivateKey) ([]string, error) {
+	collaboratorsUncast, remaining, err := rt.ChainTree.ChainTree.Dag.Resolve(ctx, collabPath)
+	if len(remaining) > 0 {
+		err = rt.createCollabPath(ctx, ownerKey)
+		return []string{}, err
+	}
+	if err != nil {
+		return []string{}, err
+	}
+
+	var (
+		collabsSemiCast []interface{}
+		ok              bool
+	)
+
+	collaborators := make([]string, 0)
+
+	if collabsSemiCast, ok = collaboratorsUncast.([]interface{}); !ok {
+		return []string{}, fmt.Errorf("collaborators value was not an interface{} slice; was a %T: %+v", collaboratorsUncast, collaboratorsUncast)
+	}
+	for _, c := range collabsSemiCast {
+		var cStr string
+		if cStr, ok = c.(string); !ok {
+			return []string{}, fmt.Errorf("collaborator value was not a string; was a %T: %+v", c, c)
+		}
+		collaborators = append(collaborators, cStr)
+	}
+
+	return collaborators, nil
+}
+
+func (rt *RepoTree) RemoveCollaborators(ctx context.Context, collaborators []string, ownerKey *ecdsa.PrivateKey) error {
+	return rt.updateCollaborators(ctx, ownerKey, func(current []string) []string {
+		newCollaborators := make([]string, 0)
+
+		for _, cc := range current {
+			var remove bool
+			for _, c := range collaborators {
+				if cc == c {
+					remove = true
+					break
+				}
+			}
+			if !remove {
+				newCollaborators = append(newCollaborators, cc)
+			}
+		}
+
+		return newCollaborators
+	})
 }

--- a/tupelo/repotree/repotree.go
+++ b/tupelo/repotree/repotree.go
@@ -31,9 +31,7 @@ func init() {
 	namedTreeGen = &namedtree.Generator{Namespace: repoSalt}
 }
 
-type Options struct {
-	*namedtree.Options
-}
+type Options namedtree.Options
 
 type RepoTree struct {
 	*namedtree.NamedTree
@@ -49,8 +47,9 @@ func Find(ctx context.Context, repo string, client *tupelo.Client) (*RepoTree, e
 }
 
 func Create(ctx context.Context, opts *Options, ownerKey *ecdsa.PrivateKey) (*RepoTree, error) {
-	log.Debugf("creating new repotree with options: %+v", opts.Options)
-	namedTree, err := namedTreeGen.New(ctx, opts.Options)
+	log.Debugf("creating new repotree with options: %+v", opts)
+	ntOpts := namedtree.Options(*opts)
+	namedTree, err := namedTreeGen.New(ctx, &ntOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/tupelo/repotree/repotree_test.go
+++ b/tupelo/repotree/repotree_test.go
@@ -7,12 +7,11 @@ import (
 )
 
 func TestRepoIsCaseInsenitive(t *testing.T) {
-
-	lower, err := Did("quorumcontrol/dgit-test")
+	lower, err := namedTreeGen.Did("quorumcontrol/dgit-test")
 	require.Nil(t, err)
-	mixed, err := Did("quorumcontrol/DGIT-test")
+	mixed, err := namedTreeGen.Did("quorumcontrol/DGIT-test")
 	require.Nil(t, err)
-	upper, err := Did("QUORUMCONTROL/DGIT-TEST")
+	upper, err := namedTreeGen.Did("QUORUMCONTROL/DGIT-TEST")
 	require.Nil(t, err)
 
 	require.Equal(t, lower, mixed)

--- a/tupelo/usertree/usertree.go
+++ b/tupelo/usertree/usertree.go
@@ -16,9 +16,7 @@ func init() {
 	namedTreeGen = &namedtree.Generator{Namespace: userSalt}
 }
 
-type Options struct {
-	*namedtree.Options
-}
+type Options namedtree.Options
 
 func Find(ctx context.Context, username string, client *tupelo.Client) (*namedtree.NamedTree, error) {
 	namedTreeGen.Client = client
@@ -26,7 +24,8 @@ func Find(ctx context.Context, username string, client *tupelo.Client) (*namedtr
 }
 
 func Create(ctx context.Context, opts *Options) (*namedtree.NamedTree, error) {
-	namedTree, err := namedTreeGen.New(ctx, opts.Options)
+	ntOpts := namedtree.Options(*opts)
+	namedTree, err := namedTreeGen.New(ctx, &ntOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/tupelo/usertree/usertree.go
+++ b/tupelo/usertree/usertree.go
@@ -1,4 +1,4 @@
-package repotree
+package usertree
 
 import (
 	"context"
@@ -8,21 +8,21 @@ import (
 	"github.com/quorumcontrol/dgit/tupelo/namedtree"
 )
 
-const repoSalt = "decentragit-0.0.0-alpha"
+const userSalt = "dgit-user-v0"
 
 var namedTreeGen *namedtree.Generator
 
 func init() {
-	namedTreeGen = &namedtree.Generator{Namespace: repoSalt}
+	namedTreeGen = &namedtree.Generator{Namespace: userSalt}
 }
 
 type Options struct {
 	*namedtree.Options
 }
 
-func Find(ctx context.Context, repo string, client *tupelo.Client) (*namedtree.NamedTree, error) {
+func Find(ctx context.Context, username string, client *tupelo.Client) (*namedtree.NamedTree, error) {
 	namedTreeGen.Client = client
-	return namedTreeGen.Find(ctx, repo)
+	return namedTreeGen.Find(ctx, username)
 }
 
 func Create(ctx context.Context, opts *Options) (*namedtree.NamedTree, error) {


### PR DESCRIPTION
Implements #31.

Adds new `team (add | list | remove)` and `whoami` commands. Asks for username on init and stores it in git config. A global default username can be configured with `git config --global dgit.username [username]`, but it also looks for any configured GitHub username and suggests that for your dgit username. It then suggests `username/basedir` for the full repo name.

It can also migrate the old `dgit.default` keyring entries to the new `dgit.[username]` entries.

And a few other small fixes & improvements (which I will pull into their own PR if controversial).

Tests shmests... ;)