### PR TITLE
Ensure zlib buffer is closed before writing objects to storage

### DIFF
--- a/storage/chaintree/object.go
+++ b/storage/chaintree/object.go
@@ -116,25 +116,10 @@ func (s *ObjectStorage) SetEncodedObjectTxn(o plumbing.EncodedObject) (*transact
 		return nil, plumbing.ErrInvalidType
 	}
 
-	buf := bytes.NewBuffer(nil)
-
-	writer := objfile.NewWriter(buf)
-	defer writer.Close()
-
-	reader, err := o.Reader()
+	buf, err := storage.ZlibBufferForObject(o)
 	if err != nil {
 		return nil, err
 	}
-	defer reader.Close()
-
-	if err := writer.WriteHeader(o.Type(), o.Size()); err != nil {
-		return nil, err
-	}
-
-	if _, err = io.Copy(writer, reader); err != nil {
-		return nil, err
-	}
-	writer.Close()
 
 	objectBytes, err := ioutil.ReadAll(buf)
 	if err != nil {

--- a/storage/object_test.go
+++ b/storage/object_test.go
@@ -1,0 +1,25 @@
+package storage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestZlibBufferForObject(t *testing.T) {
+	o := &plumbing.MemoryObject{}
+	o.SetType(plumbing.BlobObject)
+	o.SetSize(14)
+	_, err := o.Write([]byte("Hello, World!\n"))
+	require.Nil(t, err)
+	require.Equal(t, o.Hash().String(), "8ab686eafeb1f44702738c8b0f24f2567c36da6d")
+
+	buf, err := ZlibBufferForObject(o)
+	require.Nil(t, err)
+
+	fmt.Printf("%v", buf.Bytes())
+
+	require.Equal(t, buf.Bytes(), []byte{120, 156, 74, 202, 201, 79, 82, 48, 52, 97, 240, 72, 205, 201, 201, 215, 81, 8, 207, 47, 202, 73, 81, 228, 2, 4, 0, 0, 255, 255, 78, 21, 6, 152})
+}

--- a/storage/siaskynet/net.go
+++ b/storage/siaskynet/net.go
@@ -1,13 +1,13 @@
 package siaskynet
 
 import (
-	"bytes"
 	"io"
 	"sync"
 
 	"github.com/NebulousLabs/go-skynet"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/format/objfile"
+	"github.com/quorumcontrol/dgit/storage"
 	"go.uber.org/zap"
 )
 
@@ -47,21 +47,8 @@ func InitSkynet(uploaderCount, downloaderCount int) *Skynet {
 }
 
 func (s *Skynet) uploadObject(o plumbing.EncodedObject) (string, error) {
-	buf := bytes.NewBuffer(nil)
-
-	writer := objfile.NewWriter(buf)
-	defer writer.Close()
-
-	reader, err := o.Reader()
+	buf, err := storage.ZlibBufferForObject(o)
 	if err != nil {
-		return "", err
-	}
-
-	if err = writer.WriteHeader(o.Type(), o.Size()); err != nil {
-		return "", err
-	}
-
-	if _, err = io.Copy(writer, reader); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
All of the skynet objects were only getting the zlib header because the `defer writer.Close()` wasn't triggering till after the skynet upload call. This ensures the buffer is always called by pulling it out into its own method, used in both chaintree and sia stores, and then adds a test (which fails without the close).