### PR TITLE
disable reference fetch for HEAD for now

### DIFF
--- a/storage/chaintree/reference.go
+++ b/storage/chaintree/reference.go
@@ -71,6 +71,13 @@ func (s *ReferenceStorage) CheckAndSetReference(ref *plumbing.Reference, old *pl
 
 // Reference returns the reference for a given reference name.
 func (s *ReferenceStorage) Reference(n plumbing.ReferenceName) (*plumbing.Reference, error) {
+	// TODO: store default branch in chaintree as HEAD
+	// random sha1s are showing up as HEAD from mystery code,
+	// so for now, disable HEAD requests
+	if n.String() == plumbing.HEAD.String() {
+		return nil, plumbing.ErrReferenceNotFound
+	}
+
 	refPath := append([]string{"tree", "data"}, strings.Split(n.String(), "/")...)
 	valUncast, _, err := s.ChainTree.ChainTree.Dag.Resolve(context.Background(), refPath)
 	if err != nil {


### PR DESCRIPTION
For some reason a few repo chaintrees have had a dangling sha1 inserted into `tree/data/HEADS` inserted, causing clones to raise a `You appear to have cloned an empty repository.`.

In the future our intention is to add explicit default branches to the repo (aka HEAD), but this fixes the current issue in the mean time. 