### PR TITLE
fix github action by ensuring all objects are  available to dgit

### DIFF
--- a/.github/workflows/dgit-push.yml
+++ b/.github/workflows/dgit-push.yml
@@ -7,8 +7,11 @@ jobs:
     steps:
     - name: Check out repository
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Push to dgit
       uses: quorumcontrol/dgit-github-action@master
       env:
+        GIT_PUSH_ARGS: "--force"
         DGIT_PRIVATE_KEY: ${{ secrets.DGIT_PRIVATE_KEY }}
         DGIT_LOG_LEVEL: debug


### PR DESCRIPTION
the key is the `fetch-depth: 0`, which pulls all history / objects for the current branch on checkout.