### PR TITLE
default to sia in all non test calls

### DIFF
--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -147,7 +147,7 @@ func (i *Initializer) findOrCreateRepoTree(ctx context.Context) (*consensus.Sign
 	}
 
 	// repo doesn't exist, create it
-	newTree, err := client.CreateRepoTree(ctx, endpoint, auth, "siaskynet")
+	newTree, err := client.CreateRepoTree(ctx, endpoint, auth, os.Getenv("DGIT_OBJ_STORAGE"))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
currently `dgit init` always uses sia, but a direct `git remote add` with a new dgit url would use `chaintree` storage, unless `DGIT_OBJ_STORAGE=siaskynet` was set. This make sia the default on repo chaintree creation regardless of caller. Tests still use the `chaintree` store