### PR TITLE
User namespace restricted repos

### DIFF
--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -2,6 +2,7 @@ package initializer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -241,6 +242,11 @@ func (i *Initializer) findOrCreateRepoTree(ctx context.Context) (*repotree.RepoT
 	// repo doesn't exist, create it
 	log.Debugf("creating new repo tree with endpoint %+v and auth %+v", i.repo.MustEndpoint(), auth)
 	newTree, err := client.CreateRepoTree(ctx, i.repo.MustEndpoint(), auth)
+	if errors.Is(err, usertree.ErrNotFound) {
+		return nil, fmt.Errorf(msg.Parse(msg.UserNotFund, map[string]interface{}{
+			"user": strings.Split(i.repo.MustName(), "/")[0],
+		}))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/msg/messages.go
+++ b/msg/messages.go
@@ -54,6 +54,10 @@ var PrivateKeyNotFound = `
 Could not load your dgit private key from {{.keyringProvider}}. Try running 'dgit init' again.
 `
 
+var UserNotFund = `
+user {{.user}} does not exist
+`
+
 var RepoCreated = `
 Your dgit repo has been created at '{{.repo}}'.
 

--- a/msg/messages.go
+++ b/msg/messages.go
@@ -58,6 +58,8 @@ var UserNotFund = `
 user {{.user}} does not exist
 `
 
+var UserNotConfigured = "\nNo dgit username configured. Run `git config --global dgit.username your-username`.\n"
+
 var RepoCreated = `
 Your dgit repo has been created at '{{.repo}}'.
 

--- a/remotehelper/runner.go
+++ b/remotehelper/runner.go
@@ -309,7 +309,7 @@ func (r *Runner) auth() (transport.AuthMethod, error) {
 	}
 
 	if username == "" {
-		log.Fatal("No dgit username configured. Run `git config --global dgit.username your-username`.")
+		return nil, fmt.Errorf(msg.UserNotConfigured)
 	}
 
 	privateKey, err := keyring.FindPrivateKey(r.keyring, username)

--- a/tupelo/repotree/repotree.go
+++ b/tupelo/repotree/repotree.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	logging "github.com/ipfs/go-log"
 	"github.com/quorumcontrol/chaintree/chaintree"
 	"github.com/quorumcontrol/messages/v2/build/go/transactions"
+	"github.com/quorumcontrol/tupelo-go-sdk/consensus"
 	tupelo "github.com/quorumcontrol/tupelo-go-sdk/gossip/client"
 
 	"github.com/quorumcontrol/dgit/tupelo/namedtree"
@@ -27,6 +29,8 @@ var collabPath = []string{"tree", "data", "dgit", "team"}
 
 var namedTreeGen *namedtree.Generator
 
+var ErrNotFound = tupelo.ErrNotFound
+
 func init() {
 	namedTreeGen = &namedtree.Generator{Namespace: repoSalt}
 }
@@ -34,22 +38,84 @@ func init() {
 type Options namedtree.Options
 
 type RepoTree struct {
-	*namedtree.NamedTree
+	Name      string
+	ChainTree *consensus.SignedChainTree
+	Tupelo    *tupelo.Client
 }
 
 func Find(ctx context.Context, repo string, client *tupelo.Client) (*RepoTree, error) {
-	namedTreeGen.Client = client
-	nt, err := namedTreeGen.Find(ctx, repo)
+	log.Debugf("looking for repo %s", repo)
+
+	username := strings.Split(repo, "/")[0]
+	reponame := strings.Join(strings.Split(repo, "/")[1:], "/")
+
+	userChainTree, err := usertree.Find(ctx, username, client)
 	if err != nil {
 		return nil, err
 	}
-	return &RepoTree{nt}, nil
+	log.Debugf("user chaintree did: %s", userChainTree.ChainTree.MustId())
+
+	userRepos, err := userChainTree.Repos(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	repoDid, ok := userRepos[reponame]
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	chainTree, err := client.GetLatest(ctx, repoDid)
+	if err == tupelo.ErrNotFound {
+		return nil, ErrNotFound
+	}
+	log.Debugf("repo chaintree found, did: %s", chainTree.MustId())
+
+	return &RepoTree{
+		Name:      repo,
+		ChainTree: chainTree,
+		Tupelo:    client,
+	}, nil
 }
 
 func Create(ctx context.Context, opts *Options, ownerKey *ecdsa.PrivateKey) (*RepoTree, error) {
 	log.Debugf("creating new repotree with options: %+v", opts)
-	ntOpts := namedtree.Options(*opts)
-	namedTree, err := namedTreeGen.New(ctx, &ntOpts)
+
+	username := strings.Split(opts.Name, "/")[0]
+	reponame := strings.Join(strings.Split(opts.Name, "/")[1:], "/")
+
+	userChainTree, err := usertree.Find(ctx, username, opts.Tupelo)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("user chaintree did: %s", userChainTree.ChainTree.MustId())
+
+	userRepos, err := userChainTree.Repos(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	_, ok := userRepos[reponame]
+	if ok {
+		return nil, fmt.Errorf("repo %s already exists for %s", reponame, username)
+	}
+
+	creationKey, err := crypto.GenerateKey()
+	if err != nil {
+		return nil, err
+	}
+
+	chainTree, err := consensus.NewSignedChainTree(ctx, creationKey.PublicKey, opts.NodeStore)
+	if err != nil {
+		return nil, err
+	}
+
+	setOwnershipTxn, err := chaintree.NewSetOwnershipTransaction(opts.Owners)
+	if err != nil {
+		return nil, err
+	}
+
+	creationTimestampTxn, err := chaintree.NewSetDataTransaction("dgit/createdAt", time.Now().Unix())
 	if err != nil {
 		return nil, err
 	}
@@ -77,14 +143,24 @@ func Create(ctx context.Context, opts *Options, ownerKey *ecdsa.PrivateKey) (*Re
 		return nil, err
 	}
 
-	txns := []*transactions.Transaction{repoTxn, configTxn, teamTxn}
+	txns := []*transactions.Transaction{setOwnershipTxn, creationTimestampTxn, repoTxn, configTxn, teamTxn}
 
-	_, err = opts.Tupelo.PlayTransactions(ctx, namedTree.ChainTree, ownerKey, txns)
+	_, err = opts.Tupelo.PlayTransactions(ctx, chainTree, creationKey, txns)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("created %s repo chaintree with did: %s", opts.Name, chainTree.MustId())
+
+	err = userChainTree.AddRepo(ctx, ownerKey, reponame, chainTree.MustId())
 	if err != nil {
 		return nil, err
 	}
 
-	return &RepoTree{namedTree}, nil
+	return &RepoTree{
+		Name:      reponame,
+		ChainTree: chainTree,
+		Tupelo:    opts.Tupelo,
+	}, nil
 }
 
 func (rt *RepoTree) usernameToKeyAddr(ctx context.Context, username string) (string, error) {
@@ -99,6 +175,10 @@ func (rt *RepoTree) usernameToKeyAddr(ctx context.Context, username string) (str
 	}
 
 	return auths[0], nil
+}
+
+func (rt *RepoTree) Did() string {
+	return rt.ChainTree.MustId()
 }
 
 // updateCollaborators takes an ownerKey for the update transaction (if needed)

--- a/tupelo/repotree/repotree.go
+++ b/tupelo/repotree/repotree.go
@@ -54,7 +54,7 @@ func Find(ctx context.Context, repo string, client *tupelo.Client) (*RepoTree, e
 	if err != nil {
 		return nil, err
 	}
-	log.Debugf("user chaintree did: %s", userChainTree.ChainTree.MustId())
+	log.Debugf("user chaintree found for %s - %s", username, userChainTree.ChainTree.MustId())
 
 	userRepos, err := userChainTree.Repos(ctx)
 	if err != nil {
@@ -70,7 +70,7 @@ func Find(ctx context.Context, repo string, client *tupelo.Client) (*RepoTree, e
 	if err == tupelo.ErrNotFound {
 		return nil, ErrNotFound
 	}
-	log.Debugf("repo chaintree found, did: %s", chainTree.MustId())
+	log.Debugf("repo chaintree found for %s - %s", repo, chainTree.MustId())
 
 	return &RepoTree{
 		Name:      repo,
@@ -92,7 +92,7 @@ func Create(ctx context.Context, opts *Options, ownerKey *ecdsa.PrivateKey) (*Re
 	if err != nil {
 		return nil, err
 	}
-	log.Debugf("user chaintree did: %s", userChainTree.ChainTree.MustId())
+	log.Debugf("user chaintree found for %s - %s", username, userChainTree.ChainTree.MustId())
 
 	isOwner, err := userChainTree.IsOwner(ctx, crypto.PubkeyToAddress(ownerKey.PublicKey).String())
 	if err != nil {

--- a/tupelo/usertree/usertree.go
+++ b/tupelo/usertree/usertree.go
@@ -2,15 +2,29 @@ package usertree
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"strings"
 
+	logging "github.com/ipfs/go-log"
+	"github.com/quorumcontrol/chaintree/chaintree"
+	"github.com/quorumcontrol/messages/v2/build/go/transactions"
 	tupelo "github.com/quorumcontrol/tupelo-go-sdk/gossip/client"
 
 	"github.com/quorumcontrol/dgit/tupelo/namedtree"
 )
 
+type UserTree struct {
+	*namedtree.NamedTree
+}
+
+var log = logging.Logger("dgit.usertree")
+
 const userSalt = "dgit-user-v0"
 
 var namedTreeGen *namedtree.Generator
+
+var reposMapPath = []string{"dgit", "repos"}
 
 func init() {
 	namedTreeGen = &namedtree.Generator{Namespace: userSalt}
@@ -18,17 +32,66 @@ func init() {
 
 type Options namedtree.Options
 
-func Find(ctx context.Context, username string, client *tupelo.Client) (*namedtree.NamedTree, error) {
+func Find(ctx context.Context, username string, client *tupelo.Client) (*UserTree, error) {
 	namedTreeGen.Client = client
-	return namedTreeGen.Find(ctx, username)
+	namedTree, err := namedTreeGen.Find(ctx, username)
+	if err != nil {
+		return nil, err
+	}
+	return &UserTree{namedTree}, nil
 }
 
-func Create(ctx context.Context, opts *Options) (*namedtree.NamedTree, error) {
+func Create(ctx context.Context, opts *Options) (*UserTree, error) {
 	ntOpts := namedtree.Options(*opts)
 	namedTree, err := namedTreeGen.New(ctx, &ntOpts)
 	if err != nil {
 		return nil, err
 	}
 
-	return namedTree, nil
+	log.Debugf("created user %s (%s)", opts.Name, namedTree.Did())
+
+	return &UserTree{namedTree}, nil
+}
+
+func (t *UserTree) AddRepo(ctx context.Context, ownerKey *ecdsa.PrivateKey, reponame string, did string) error {
+	log.Debugf("adding repo %s (%s) to user %s (%s)", reponame, did, t.Name, t.Did())
+
+	path := strings.Join(append(reposMapPath, reponame), "/")
+	repoTxn, err := chaintree.NewSetDataTransaction(path, did)
+	if err != nil {
+		return err
+	}
+
+	_, err = t.Tupelo.PlayTransactions(ctx, t.ChainTree, ownerKey, []*transactions.Transaction{repoTxn})
+	return err
+}
+
+func (t *UserTree) Repos(ctx context.Context) (map[string]string, error) {
+	path := append([]string{"tree", "data"}, reposMapPath...)
+	valMap := make(map[string]string)
+	valUncast, _, err := t.ChainTree.ChainTree.Dag.Resolve(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	if valUncast == nil {
+		return valMap, nil
+	}
+
+	valMapUncast, ok := valUncast.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("path %v is %T, expected map", path, valUncast)
+	}
+
+	for k, v := range valMapUncast {
+		if v == nil {
+			continue
+		}
+		vstr, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("key %s at path %v is %T, expected string", k, path, v)
+		}
+		valMap[k] = vstr
+	}
+
+	return valMap, nil
 }


### PR DESCRIPTION
This routes the creation and lookup of repo ChainTrees through the user ChainTree to ensure users are always in control of packages under their name. 

As this PR stands now, **this is a breaking change**. A simple rerun of `dgit init` will fix that though. 