### PR TITLE
add __doctype field to all chaintrees

### DIFF
--- a/tupelo/namedtree/namedtree.go
+++ b/tupelo/namedtree/namedtree.go
@@ -63,7 +63,12 @@ func (g *Generator) New(ctx context.Context, opts *Options) (*NamedTree, error) 
 		return nil, err
 	}
 
-	txns := []*transactions.Transaction{setOwnershipTxn, creationTimestampTxn}
+	docTypeTxn, err := chaintree.NewSetDataTransaction("__doctype", "dgit")
+	if err != nil {
+		return nil, err
+	}
+
+	txns := []*transactions.Transaction{setOwnershipTxn, creationTimestampTxn, docTypeTxn}
 
 	_, err = opts.Tupelo.PlayTransactions(ctx, chainTree, gKey, txns)
 	if err != nil {

--- a/tupelo/repotree/repotree.go
+++ b/tupelo/repotree/repotree.go
@@ -132,6 +132,11 @@ func Create(ctx context.Context, opts *Options, ownerKey *ecdsa.PrivateKey) (*Re
 		return nil, err
 	}
 
+	docTypeTxn, err := chaintree.NewSetDataTransaction("__doctype", "dgit")
+	if err != nil {
+		return nil, err
+	}
+
 	repoTxn, err := chaintree.NewSetDataTransaction("dgit/repo", opts.Name)
 	if err != nil {
 		return nil, err
@@ -155,7 +160,7 @@ func Create(ctx context.Context, opts *Options, ownerKey *ecdsa.PrivateKey) (*Re
 		return nil, err
 	}
 
-	txns := []*transactions.Transaction{setOwnershipTxn, creationTimestampTxn, repoTxn, configTxn, teamTxn}
+	txns := []*transactions.Transaction{setOwnershipTxn, creationTimestampTxn, docTypeTxn, repoTxn, configTxn, teamTxn}
 
 	_, err = opts.Tupelo.PlayTransactions(ctx, chainTree, creationKey, txns)
 	if err != nil {


### PR DESCRIPTION
Just explicitly adds `__doctype=dgit` classification rather than assuming based on some data in the tree.