### PR TITLE
add prefix environment variable and install dgit under that prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 gosources = $(shell find . -type f -name '*.go' -print)
 
+FIRSTGOPATH = $(firstword $(subst :, ,$(GOPATH)))
 HEAD_TAG := $(shell if [ -d .git ]; then git tag --points-at HEAD; fi)
 GIT_REV := $(shell if [ -d .git ]; then git rev-parse --short HEAD; fi)
 GIT_VERSION := $(or $(HEAD_TAG),$(GIT_REV))
@@ -9,7 +10,7 @@ GOLDFLAGS += -X main.Version=$(VERSION)
 GOFLAGS = -ldflags "$(GOLDFLAGS)"
 
 ifeq ($(PREFIX),)
-    PREFIX := /usr/local
+	PREFIX := $(or $(FIRSTGOPATH),/usr/local)
 endif
 
 all: build


### PR DESCRIPTION
This patch allows for setting the install prefix with the `PREFIX` environment variable instead of relying on `GOPATH` to be set and installing it there. It also uses a `DESTDIR` environment variable that most linux package managers use to install packages into an intermediate sandbox (and works normally when `DESTDIR` is not set). 

This is a more standard way (beyond go) to install binary packages on unix like system with Makefiles because it allows for building the package as an unprivileged user (where `GOPATH` is more likely to be set), but installing the package system wide as root (where `GOPATH` is not likely to be set). This will be more flexible for writing install scripts for other operating systems and distributions.