### PR TITLE
Rename: git-dg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@
 *.dylib
 decentragit-remote
 /dgit
+/git-dg
 /dgit.tar.gz
+/decentragit.tar.gz
 
 # Test binary, built with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -30,27 +30,27 @@ dist/arm64v%/git-dg: go.mod go.sum $(gosources)
 
 build-linux-arm: dist/armv6/git-dg dist/armv7/git-dg dist/arm64v8/git-dg
 
-decentragit.tar.gz: git-dg git-remote-dgit
+decentragit.tar.gz: git-dg git-remote-dg
 	tar -czvf decentragit.tar.gz $^
 
-dist/armv%/decentragit.tar.gz: dist/armv%/git-dg git-remote-dgit
+dist/armv%/decentragit.tar.gz: dist/armv%/git-dg git-remote-dg
 	tar -czvf $@ $^
 
-dist/arm64v%/decentragit.tar.gz: dist/arm64v%/git-dg git-remote-dgit
+dist/arm64v%/decentragit.tar.gz: dist/arm64v%/git-dg git-remote-dg
 	tar -czvf $@ $^
 
 tarball: decentragit.tar.gz
 
 tarball-linux-arm: dist/armv6/decentragit.tar.gz dist/armv7/decentragit.tar.gz dist/arm64v8/decentragit.tar.gz
 
-install: git-dg git-remote-dgit
+install: git-dg git-remote-dg
 	install -d $(DESTDIR)$(PREFIX)/bin/
 	install -m 755 git-dg $(DESTDIR)$(PREFIX)/bin/
-	install -m 755 git-remote-dgit $(DESTDIR)$(PREFIX)/bin/
+	install -m 755 git-remote-dg $(DESTDIR)$(PREFIX)/bin/
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/git-dg
-	rm -f $(DESTDIR)$(PREFIX)/bin/git-remote-dgit
+	rm -f $(DESTDIR)$(PREFIX)/bin/git-remote-dg
 
 test:
 	go test ./...

--- a/Makefile
+++ b/Makefile
@@ -15,47 +15,53 @@ endif
 
 all: build
 
-dgit: go.mod go.sum $(gosources)
-	go build -o dgit $(GOFLAGS) .
+git-dg: go.mod go.sum $(gosources)
+	go build -o $@ $(GOFLAGS) .
 
-build: dgit
+build: git-dg
 
-dist/armv%/dgit: go.mod go.sum $(gosources)
+dist/armv%/git-dg: go.mod go.sum $(gosources)
 	mkdir -p $(@D)
-	env GOOS=linux GOARCH=arm GOARM=$* go build -o $@
+	env GOOS=linux GOARCH=arm GOARM=$* go build -o $@ $(GOFLAGS)
 
-dist/arm64v%/dgit: go.mod go.sum $(gosources)
+dist/arm64v%/git-dg: go.mod go.sum $(gosources)
 	mkdir -p $(@D)
-	env GOOS=linux GOARCH=arm64 go build -o $@
+	env GOOS=linux GOARCH=arm64 go build -o $@ $(GOFLAGS)
 
-build-linux-arm: dist/armv6/dgit dist/armv7/dgit dist/arm64v8/dgit
+build-linux-arm: dist/armv6/git-dg dist/armv7/git-dg dist/arm64v8/git-dg
 
-dgit.tar.gz: dgit git-remote-dgit
-	tar -czvf dgit.tar.gz $^
+$(FIRSTGOPATH)/bin/git-dg: git-dg
+	cp $< $(FIRSTGOPATH)/bin/$<
 
-dist/armv%/dgit.tar.gz: dist/armv%/dgit git-remote-dgit
+$(FIRSTGOPATH)/bin/git-remote-dgit: git-remote-dgit
+	cp $< $(FIRSTGOPATH)/bin/$<
+
+decentragit.tar.gz: git-dg git-remote-dgit
+	tar -czvf decentragit.tar.gz $^
+
+dist/armv%/decentragit.tar.gz: dist/armv%/git-dg git-remote-dgit
 	tar -czvf $@ $^
 
-dist/arm64v%/dgit.tar.gz: dist/arm64v%/dgit git-remote-dgit
+dist/arm64v%/decentragit.tar.gz: dist/arm64v%/git-dg git-remote-dgit
 	tar -czvf $@ $^
 
-tarball: dgit.tar.gz
+tarball: decentragit.tar.gz
 
-tarball-linux-arm: dist/armv6/dgit.tar.gz dist/armv7/dgit.tar.gz dist/arm64v8/dgit.tar.gz
+tarball-linux-arm: dist/armv6/decentragit.tar.gz dist/armv7/decentragit.tar.gz dist/arm64v8/decentragit.tar.gz
 
-install: dgit git-remote-dgit
+install: git-dg git-remote-dgit
 	install -d $(DESTDIR)$(PREFIX)/bin/
-	install -m 755 dgit $(DESTDIR)$(PREFIX)/bin/
+	install -m 755 git-dg $(DESTDIR)$(PREFIX)/bin/
 	install -m 755 git-remote-dgit $(DESTDIR)$(PREFIX)/bin/
 
 uninstall:
-	rm -f $(DESTDIR)$(PREFIX)/bin/dgit
+	rm -f $(DESTDIR)$(PREFIX)/bin/git-dg
 	rm -f $(DESTDIR)$(PREFIX)/bin/git-remote-dgit
 
 test:
 	go test ./...
 
 clean:
-	rm -f dgit dgit.tar.gz
+	rm -f git-dg dgit.tar.gz
 
 .PHONY: all build build-linux-arm tarball tarball-linux-arm install uninstall test clean

--- a/Makefile
+++ b/Makefile
@@ -30,12 +30,6 @@ dist/arm64v%/git-dg: go.mod go.sum $(gosources)
 
 build-linux-arm: dist/armv6/git-dg dist/armv7/git-dg dist/arm64v8/git-dg
 
-$(FIRSTGOPATH)/bin/git-dg: git-dg
-	cp $< $(FIRSTGOPATH)/bin/$<
-
-$(FIRSTGOPATH)/bin/git-remote-dgit: git-remote-dgit
-	cp $< $(FIRSTGOPATH)/bin/$<
-
 decentragit.tar.gz: git-dg git-remote-dgit
 	tar -czvf decentragit.tar.gz $^
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
     <img src="dgit-black.png" alt="Logo" width="150" height="125">
   </a>
 
-  <h3 align="center">dgit</h3>
+  <h3 align="center">decentragit</h3>
 
   <p align="center">
-    <b>dgit</b> is an open-source project built by <a href="https://www.tupelo.org/">Quorum Control</a> which combines
+    <b>decentragit</b> is an open-source project built by <a href="https://www.tupelo.org/">Quorum Control</a> which combines
     the power of <br>git, the <a href="https://docs.tupelo.org/">Tupelo DLT</a> and <a href="https://siasky.net/">Skynet</a> from Sia.  <br>
-    <b>dgit</b> uses decentralized ownership and storage to make it trivial to
+    <b>decentragit</b> uses decentralized ownership and storage to make it trivial to
     create a decentralized, shareable git remote of your project.<br>
-    <b>dgit</b> accomplishes this without changing your GitHub workflow except that you can keep collaborating when it goes down.<br>
+    <b>decentragit</b> accomplishes this without changing your GitHub workflow except that you can keep collaborating when it goes down.<br>
   </p>
 </p>
 
@@ -35,13 +35,13 @@ brew tap quorumcontrol/dgit && brew install dgit
 ### Usage
 Next you will need to initialize each repo you want to make decentralized:
 ```
-dgit init
+git dg init
 ```
 
 This command does three things.<br>
-1. <b>dgit</b> sets the appropriate remote urls in your repo's .git/config file.<br>
-2. <b>dgit</b> creates a [ChainTree](https://docs.tupelo.org/docs/chaintree.html) which gets signed by the Tupelo DLT to specify ownership of the decentralized repo.<br>
-3. <b>dgit</b> stores that repo on Skynet, the decentralized storage solution from Sia. 
+1. <b>decentragit</b> sets the appropriate remote urls in your repo's .git/config file.<br>
+2. <b>decentragit</b> creates a [ChainTree](https://docs.tupelo.org/docs/chaintree.html) which gets signed by the Tupelo DLT to specify ownership of the decentralized repo.<br>
+3. <b>decentragit</b> stores that repo on Skynet, the decentralized storage solution from Sia. 
 
 From there you can proceed with normal git commands.<br>
 
@@ -51,15 +51,15 @@ As an example:
 <br>
 
 If you want to keep your decentralized, shareable git remote in sync with your GitHub repo adding
-a simple github action as illustrated in [dgit-github-action](https://github.com/quorumcontrol/dgit-github-action) is all it takes.  Once completed yourde dgit decentralized shareable remote will always be up to date and ready when you need it.<br>
+a simple github action as illustrated in [dgit-github-action](https://github.com/quorumcontrol/dgit-github-action) is all it takes.  Once completed your decentragit decentralized shareable remote will always be up to date and ready when you need it.<br>
 
 #### Collaborators
 
-You can manage your repo's team of collaborators with the `dgit team` command:
+You can manage your repo's team of collaborators with the `git gd team` command:
 
-* `dgit team add [collaborator usernames]`
-* `dgit team list`
-* `dgit team remove [usernames]`
+* `git dg team add [collaborator usernames]`
+* `git dg team list`
+* `git dg team remove [usernames]`
 
 Anyone on the team will be allowed to push to the repo in the current directory.
 
@@ -67,8 +67,8 @@ Anyone on the team will be allowed to push to the repo in the current directory.
 
 - Username can be set any of the following ways:
   - `DGIT_USERNAME=[username]` env var
-  - `git config --global dgit.username [username]` sets it in `~/.gitconfig`
-  - `git config dgit.username [username]` sets it in `./.git/config`
+  - `git config --global decentragit.username [username]` sets it in `~/.gitconfig`
+  - `git config decentragit.username [username]` sets it in `./.git/config`
 
 ### FAQ
 
@@ -82,7 +82,7 @@ You can find answers to some of the most [frequently asked questions on the wiki
 
 ### Building
 - Clone this repo.
-- Run `make`. Generates `./dgit` in top level dir.
+- Run `make`. Generates `./git-dg` in top level dir.
 
 <!-- CONTRIBUTING -->
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ This command does three things.<br>
 
 From there you can proceed with normal git commands.<br>
 
-If you ever want to pull from the mirror you can specify the mirror with a "dgit:".<br>
+If you ever want to pull from the mirror you can specify the mirror with a "dg:".<br>
 As an example:
-`git clone dgit://your_username/repo_name`
+`git clone dg://your_username/repo_name`
 <br>
 
 If you want to keep your decentralized, shareable git remote in sync with your GitHub repo adding

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -16,9 +16,9 @@ func init() {
 
 var initCommand = &cobra.Command{
 	Use:   "init",
-	Short: "Get rolling with dgit!",
+	Short: "Get rolling with decentragit!",
 	// TODO: better explanation
-	Long: `Sets up a repo to leverage dgit.`,
+	Long: `Sets up a repo to leverage decentragit.`,
 	Args: cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/remotehelper.go
+++ b/cmd/remotehelper.go
@@ -51,7 +51,7 @@ var remoteHelperCommand = &cobra.Command{
 
 		r := remotehelper.New(local)
 
-		log.Infof("dgit remote helper loaded for %s", os.Getenv("GIT_DIR"))
+		log.Infof("decentragit remote helper loaded for %s", os.Getenv("GIT_DIR"))
 
 		if len(args) < 2 {
 			fmt.Fprintln(os.Stderr, "Usage: git-remote-dgit <remote-name> <url>")
@@ -60,7 +60,7 @@ var remoteHelperCommand = &cobra.Command{
 
 		client, err := dgit.NewClient(ctx, os.Getenv("GIT_DIR"))
 		if err != nil {
-			fmt.Fprintln(os.Stderr, fmt.Sprintf("error starting dgit client: %v", err))
+			fmt.Fprintln(os.Stderr, fmt.Sprintf("error starting decentragit client: %v", err))
 			os.Exit(1)
 		}
 		client.RegisterAsDefault()

--- a/cmd/remotehelper.go
+++ b/cmd/remotehelper.go
@@ -23,7 +23,7 @@ func init() {
 var remoteHelperCommand = &cobra.Command{
 	Use:    "remote-helper",
 	Short:  "A git-remote-helper called by git directly. Not for direct use!",
-	Long:   `Implements a git-remote-helper (https://git-scm.com/docs/git-remote-helpers), registering and handling the dgit:// protocol.`,
+	Long:   `Implements a git-remote-helper (https://git-scm.com/docs/git-remote-helpers), registering and handling the dg:// protocol.`,
 	Args:   cobra.ArbitraryArgs,
 	Hidden: true,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -54,7 +54,7 @@ var remoteHelperCommand = &cobra.Command{
 		log.Infof("decentragit remote helper loaded for %s", os.Getenv("GIT_DIR"))
 
 		if len(args) < 2 {
-			fmt.Fprintln(os.Stderr, "Usage: git-remote-dgit <remote-name> <url>")
+			fmt.Fprintln(os.Stderr, "Usage: git-remote-dg <remote-name> <url>")
 			os.Exit(1)
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,12 +12,11 @@ import (
 
 const defaultLogLevel = "PANIC"
 
-var log = logging.Logger("dgit.cmd")
+var log = logging.Logger("decentragit.cmd")
 
 var rootCmd = &cobra.Command{
-	Use:   "dgit",
-	Short: "dgit is git with decentralized ownership and storage",
-	Long:  `This is the dgit CLI, useful for initializing dgit in repos.`,
+	Use:   "git gd [command]",
+	Short: "decentragit is git with decentralized ownership and storage",
 }
 
 func Execute() {
@@ -31,7 +30,7 @@ func Execute() {
 }
 
 func globalDebugLogs() {
-	log.Infof("dgit version: " + Version)
+	log.Infof("decentragit version: " + Version)
 	log.Infof("goos: " + runtime.GOOS)
 	log.Infof("goarch: " + runtime.GOARCH)
 }
@@ -40,13 +39,13 @@ func setLogLevel() {
 	// turn off all logging, mainly for silencing tupelo-go-sdk ERROR logs
 	logging.SetAllLoggers(logging.LevelPanic)
 
-	// now set dgit.* logs if applicable
+	// now set decentragit.* logs if applicable
 	logLevelStr, ok := os.LookupEnv("DGIT_LOG_LEVEL")
 	if !ok {
 		logLevelStr = defaultLogLevel
 	}
 
-	err := logging.SetLogLevelRegex("dgit.*", strings.ToUpper(logLevelStr))
+	err := logging.SetLogLevelRegex("decentragit.*", strings.ToUpper(logLevelStr))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "invalid value %s given for DGIT_LOG_LEVEL: %v\n", logLevelStr, err)
 	}

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -38,7 +38,7 @@ func newClient(ctx context.Context, repo *dgit.Repo) (*dgit.Client, error) {
 
 	client, err := dgit.NewClient(ctx, repoGitPath)
 	if err != nil {
-		return nil, fmt.Errorf("error starting dgit client: %w", err)
+		return nil, fmt.Errorf("error starting decentragit client: %w", err)
 	}
 	client.RegisterAsDefault()
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -14,9 +14,9 @@ func init() {
 
 var versionCommand = &cobra.Command{
 	Use:   "version",
-	Short: "Print dgit version",
-	Long:  "Output dgit version to stdout",
+	Short: "Print decentragit version",
+	Long:  "Output decentragit version to stdout",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("dgit version %s\n", Version)
+		fmt.Printf("decentragit version %s\n", Version)
 	},
 }

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -1,7 +1,7 @@
 package constants
 
 const (
-	Protocol          = "dgit"
+	Protocol          = "dg"
 	DgitConfigSection = "decentragit"
-	DgitRemote        = "decentragit"
+	DgitRemote        = "dg"
 )

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -2,6 +2,6 @@ package constants
 
 const (
 	Protocol          = "dgit"
-	DgitConfigSection = "dgit"
-	DgitRemote        = "dgit"
+	DgitConfigSection = "decentragit"
+	DgitRemote        = "decentragit"
 )

--- a/git-remote-dgit
+++ b/git-remote-dgit
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dgit remote-helper $@
+git-gd remote-helper $@

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -31,7 +31,7 @@ import (
 	"github.com/quorumcontrol/dgit/tupelo/usertree"
 )
 
-var log = logging.Logger("dgit.initializer")
+var log = logging.Logger("decentragit.initializer")
 
 var validRepoName = regexp.MustCompile(`^[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+`)
 

--- a/keyring/keyring.go
+++ b/keyring/keyring.go
@@ -13,7 +13,7 @@ import (
 	logging "github.com/ipfs/go-log"
 )
 
-var log = logging.Logger("dgit.keyring")
+var log = logging.Logger("decentragit.keyring")
 
 type Keyring struct {
 	kr keyringlib.Keyring
@@ -148,7 +148,7 @@ func (k *Keyring) CreatePrivateKey(keyName string, seed []byte) (*ecdsa.PrivateK
 
 	err = k.kr.Set(privateKeyItem)
 	if err != nil {
-		return nil, fmt.Errorf("error saving private key for dgit: %v", err)
+		return nil, fmt.Errorf("error saving private key for decentragit: %v", err)
 	}
 
 	return privateKey, nil

--- a/msg/messages.go
+++ b/msg/messages.go
@@ -1,40 +1,40 @@
 package msg
 
 var Welcome = `
-Welcome to dgit!
+Welcome to decentragit!
 
-Your dgit username has been created as {{.username | bold | yellow}}. Others can grant you access to their repos by running: {{print "dgit team add " .username | bold | cyan}}.
+Your decentragit username has been created as {{.username | bold | yellow}}. Others can grant you access to their repos by running: {{print "git dg team add " .username | bold | cyan}}.
 `
 
 var AddDgitToRemote = `
-dgit would like to add {{.repourl | bold | yellow}} to the {{.remote | bold }} remote. This allows {{"git push" | bold | cyan}} to mirror this repository to dgit.
+decentragit would like to add {{.repourl | bold | yellow}} to the {{.remote | bold }} remote. This allows {{"git push" | bold | cyan}} to mirror this repository to decentragit.
 `
 
 var AddDgitToRemoteConfirm = `{{"Is that ok?" | bold | green}}`
 
 var AddedDgitToRemote = `
-Success, dgit is now superpowering the {{.remote | bold }} remote.
+Success, decentragit is now superpowering the {{.remote | bold }} remote.
 Continue using your normal git workflow and enjoy being decentralized.
 `
 
 var AddDgitRemote = `
-dgit would like to add the {{.remote |  bold }} remote to this repo so that you can fetch directly from dgit.
+decentragit would like to add the {{.remote |  bold }} remote to this repo so that you can fetch directly from decentragit.
 `
 
 var AddDgitRemoteConfirm = AddDgitToRemoteConfirm
 
 var AddedDgitRemote = `
-Success, dgit is now accessible under the {{.remote | bold }} remote.
+Success, decentragit is now accessible under the {{.remote | bold }} remote.
 {{print "git fetch " .remote | bold | cyan}} will work flawlessly from your decentralized repo.
 `
 
 var FinalInstructions = `
-You are setup and ready to roll with dgit.
+You are setup and ready to roll with decentragit.
 Just use git as you usually would and enjoy a fully decentralized repo.
 
-If you would like to clone this dgit repo on another machine, simply run {{print "git clone " .repourl | bold | cyan}}.
+If you would like to clone this decentragit repo on another machine, simply run {{print "git clone " .repourl | bold | cyan}}.
 
-If you use GitHub for this repo, we recommend adding a dgit action to keep your post-PR branches in sync on dgit.
+If you use GitHub for this repo, we recommend adding a decentragit action to keep your post-PR branches in sync on decentragit.
 You can find the necessary action here:
 {{"https://github.com/quorumcontrol/dgit-github-action" | bold | blue}}
 
@@ -57,7 +57,7 @@ var IncorrectRecoveryPhrase = `
 `
 
 var PrivateKeyNotFound = `
-Could not load your dgit private key from {{.keyringProvider | bold }}. Try running {{"dgit init" | bold | cyan}} again.
+Could not load your decentragit private key from {{.keyringProvider | bold }}. Try running {{"git dg init" | bold | cyan}} again.
 `
 
 var UserSeedPhraseCreated = `
@@ -72,24 +72,24 @@ var UserNotFound = `
 {{print "user " .user " does not exist" | bold | red}}
 `
 
-var UserNotConfigured = "\nNo dgit username configured. Run `git config --global dgit.username your-username`.\n"
+var UserNotConfigured = "\nNo decentragit username configured. Run `git config --global {{.configSection}}.username your-username`.\n"
 
 var UserRestored = `
-Your dgit user {{.username | bold | yellow}} has been restored. This machine is now authorized to push to dgit repos it owns.
+Your decentragit user {{.username | bold | yellow}} has been restored. This machine is now authorized to push to decentragit repos it owns.
 `
 
 var RepoCreated = `
-Your dgit repo has been created at {{.repo | bold | yellow}}.
+Your decentragit repo has been created at {{.repo | bold | yellow}}.
 
-dgit repo identities and authorizations are secured by Tupelo - this repo's unique id is {{.did | bold | yellow}}.
+decentragit repo identities and authorizations are secured by Tupelo - this repo's unique id is {{.did | bold | yellow}}.
 
 Storage of the repo is backed by Sia Skynet.
 `
 
 var RepoNotFound = `
-{{"dgit repository does not exist." | bold | red}}
+{{"decentragit repository does not exist." | bold | red}}
 
-You can create a dgit repository by running {{"dgit init" | bold | cyan}}.
+You can create a decentragit repository by running {{"git dg init" | bold | cyan}}.
 `
 
 var RepoNotFoundInPath = `
@@ -101,5 +101,5 @@ If you would like to create a new repo, use {{"git init" | bold | cyan}} normall
 `
 
 var UsernamePrompt = `
-{{ "What dgit username would you like to use?" | bold | green }}
+{{ "What decentragit username would you like to use?" | bold | green }}
 `

--- a/msg/parse.go
+++ b/msg/parse.go
@@ -15,7 +15,7 @@ func Parse(str string, data map[string]interface{}) string {
 	var buf bytes.Buffer
 	tmpl, err := template.New("msg.Parse").Funcs(promptui.FuncMap).Parse(str)
 	if err != nil {
-		panic(fmt.Errorf("could not compile template:\ntemplate: %s\nerr: %w", str, data, err))
+		panic(fmt.Errorf("could not compile template:\ntemplate: %s\ndata: %+v\nerr: %w", str, data, err))
 	}
 	err = tmpl.Execute(&buf, data)
 	if err != nil {

--- a/remotehelper/runner.go
+++ b/remotehelper/runner.go
@@ -59,7 +59,7 @@ func New(local *git.Repository) *Runner {
 //
 
 func (r *Runner) Run(ctx context.Context, remoteName string, remoteUrl string) error {
-	log.Infof("running git-remote-dgit on remote %s with url %s", remoteName, remoteUrl)
+	log.Infof("running git-remote-dg on remote %s with url %s", remoteName, remoteUrl)
 
 	// get the named remote as reported by git, but then
 	// create a new remote with only the url specified

--- a/remotehelper/runner.go
+++ b/remotehelper/runner.go
@@ -23,7 +23,7 @@ import (
 	"github.com/quorumcontrol/dgit/transport/dgit"
 )
 
-var log = logging.Logger("dgit.runner")
+var log = logging.Logger("decentragit.runner")
 
 type Runner struct {
 	local   *git.Repository
@@ -309,7 +309,9 @@ func (r *Runner) auth() (transport.AuthMethod, error) {
 	}
 
 	if username == "" {
-		return nil, fmt.Errorf(msg.UserNotConfigured)
+		return nil, fmt.Errorf(msg.Parse(msg.UserNotConfigured, map[string]interface{}{
+			"configSection": constants.DgitConfigSection,
+		}))
 	}
 
 	privateKey, err := r.keyring.FindPrivateKey(username)

--- a/remotehelper/runner_test.go
+++ b/remotehelper/runner_test.go
@@ -58,8 +58,8 @@ func TestRunnerIntegration(t *testing.T) {
 	local, err := git.Open(store, nil)
 	require.Nil(t, err)
 
-	// Just a random dgit url
-	endpoint, err := transport.NewEndpoint("dgit://" + username + "/test")
+	// Just a random dg url
+	endpoint, err := transport.NewEndpoint("dg://" + username + "/test")
 	require.Nil(t, err)
 
 	remoteConfig := &config.RemoteConfig{

--- a/remotehelper/runner_test.go
+++ b/remotehelper/runner_test.go
@@ -49,7 +49,7 @@ func TestRunnerIntegration(t *testing.T) {
 
 	logLevelStr, ok := os.LookupEnv("DGIT_LOG_LEVEL")
 	if ok {
-		require.Nil(t, logging.SetLogLevelRegex("dgit.*", strings.ToUpper(logLevelStr)))
+		require.Nil(t, logging.SetLogLevelRegex("decentragit.*", strings.ToUpper(logLevelStr)))
 	}
 
 	localRepoFs := fixtures.Basic().One().DotGit()

--- a/storage/chaintree/object.go
+++ b/storage/chaintree/object.go
@@ -19,7 +19,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var log = logging.Logger("dgit.storage.chaintree")
+var log = logging.Logger("decentragit.storage.chaintree")
 
 type ObjectStorage struct {
 	*storage.ChaintreeObjectStorage

--- a/storage/object.go
+++ b/storage/object.go
@@ -15,7 +15,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var log = logging.Logger("dgit.storage.object")
+var log = logging.Logger("decentragit.storage.object")
 
 type ChaintreeObjectStorer interface {
 	storer.EncodedObjectStorer

--- a/storage/siaskynet/object.go
+++ b/storage/siaskynet/object.go
@@ -20,7 +20,7 @@ import (
 
 const TupeloTxnBatchSize = 75
 
-var log = logging.Logger("dgit.storage.siaskynet")
+var log = logging.Logger("decentragit.storage.siaskynet")
 
 type ObjectStorage struct {
 	*storage.ChaintreeObjectStorage

--- a/transport/dgit/client.go
+++ b/transport/dgit/client.go
@@ -17,7 +17,7 @@ import (
 	"github.com/quorumcontrol/dgit/tupelo/repotree"
 )
 
-var log = logging.Logger("dgit.client")
+var log = logging.Logger("decentragit.client")
 
 type Client struct {
 	transport.Transport

--- a/transport/dgit/repo.go
+++ b/transport/dgit/repo.go
@@ -129,7 +129,7 @@ func (r *Repo) Username() (string, error) {
 	dgitConfig := repoConfig.Merged.Section(constants.DgitConfigSection)
 
 	if dgitConfig == nil {
-		return "", fmt.Errorf("no dgit configuration found; run `git config --global dgit.username your-username`")
+		return "", fmt.Errorf("no decentragit configuration found; run `git config --global %s.username your-username`", constants.DgitConfigSection)
 	}
 
 	username := dgitConfig.Option("username")
@@ -140,7 +140,7 @@ func (r *Repo) Username() (string, error) {
 	}
 
 	if username == "" {
-		return "", fmt.Errorf("no dgit username found; run `git config --global dgit.username your-username`")
+		return "", fmt.Errorf("no decentragit username found; run `git config --global %s.username your-username`", constants.DgitConfigSection)
 	}
 
 	return username, nil

--- a/tupelo/clientbuilder/clientbuilder.go
+++ b/tupelo/clientbuilder/clientbuilder.go
@@ -117,7 +117,7 @@ func BuildWithConfig(ctx context.Context, config *Config) (*tupelo.Client, *p2p.
 	p2pHost, peer, err := p2p.NewHostAndBitSwapPeer(
 		ctx,
 		p2p.WithDiscoveryNamespaces(ngConfig.ID),
-		p2p.WithBitswapOptions(bitswap.ProvideEnabled(false)), // maybe this should be true if there is a long running dgit node
+		p2p.WithBitswapOptions(bitswap.ProvideEnabled(false)), // maybe this should be true if there is a long running decentragit node
 		p2p.WithBlockstore(bs),
 	)
 	if err != nil {

--- a/tupelo/repotree/repotree.go
+++ b/tupelo/repotree/repotree.go
@@ -24,7 +24,7 @@ const (
 	DefaultObjectStorageType = "siaskynet"
 )
 
-var log = logging.Logger("dgit.repotree")
+var log = logging.Logger("decentragit.repotree")
 
 var collabPath = []string{"tree", "data", "dgit", "team"}
 

--- a/tupelo/usertree/usertree.go
+++ b/tupelo/usertree/usertree.go
@@ -18,7 +18,7 @@ type UserTree struct {
 	*namedtree.NamedTree
 }
 
-var log = logging.Logger("dgit.usertree")
+var log = logging.Logger("decentragit.usertree")
 
 const userSalt = "dgit-user-v0"
 


### PR DESCRIPTION
Closes #50.

Renames the project to "decentragit" and the command to "git-dg" so all commands can be invoked via git itself like so: `git dg [command]` e.g. `git dg version` instead of `dgit version`.