### PR TITLE
More dg renames

### DIFF
--- a/.github/workflows/dgit-push.yml
+++ b/.github/workflows/dgit-push.yml
@@ -13,5 +13,5 @@ jobs:
       uses: quorumcontrol/dgit-github-action@master
       env:
         GIT_PUSH_ARGS: "--force"
-        DGIT_PRIVATE_KEY: ${{ secrets.DGIT_PRIVATE_KEY }}
-        DGIT_LOG_LEVEL: debug
+        DG_PRIVATE_KEY: ${{ secrets.DGIT_PRIVATE_KEY }}
+        DG_LOG_LEVEL: debug

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Anyone on the team will be allowed to push to the repo in the current directory.
 #### Configuration
 
 - Username can be set any of the following ways:
-  - `DGIT_USERNAME=[username]` env var
+  - `DG_USERNAME=[username]` env var
   - `git config --global decentragit.username [username]` sets it in `~/.gitconfig`
   - `git config decentragit.username [username]` sets it in `./.git/config`
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,13 +40,20 @@ func setLogLevel() {
 	logging.SetAllLoggers(logging.LevelPanic)
 
 	// now set decentragit.* logs if applicable
-	logLevelStr, ok := os.LookupEnv("DGIT_LOG_LEVEL")
+	logLevelStr, ok := os.LookupEnv("DG_LOG_LEVEL")
 	if !ok {
+		logLevelStr, ok = os.LookupEnv("DGIT_LOG_LEVEL")
+		if ok {
+			log.Warningf("[DEPRECATION] - DGIT_LOG_LEVEL is deprecated, please use DG_LOG_LEVEL")
+		}
+	}
+
+	if logLevelStr == "" {
 		logLevelStr = defaultLogLevel
 	}
 
 	err := logging.SetLogLevelRegex("decentragit.*", strings.ToUpper(logLevelStr))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "invalid value %s given for DGIT_LOG_LEVEL: %v\n", logLevelStr, err)
+		fmt.Fprintf(os.Stderr, "invalid value %s given for DG_LOG_LEVEL: %v\n", logLevelStr, err)
 	}
 }

--- a/git-remote-dg
+++ b/git-remote-dg
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-git-gd remote-helper $@
+git-dg remote-helper $@

--- a/initializer/initializer.go
+++ b/initializer/initializer.go
@@ -154,7 +154,7 @@ func (i *Initializer) findOrRequestUsername() (string, error) {
 	globalUsername := repoConfig.Merged.GlobalConfig().Section(constants.DgitConfigSection).Option("username")
 
 	if username != "" && username != globalUsername {
-		log.Debugf("adding dgit.username to repo config")
+		log.Debugf("adding decentragit.username to repo config")
 		newConfig := repoConfig.Merged.AddOption(configformat.LocalScope, constants.DgitConfigSection, configformat.NoSubsection, "username", username)
 		repoConfig.Merged.SetLocalConfig(newConfig)
 		err = repoConfig.Validate()

--- a/remotehelper/runner.go
+++ b/remotehelper/runner.go
@@ -305,6 +305,11 @@ func (r *Runner) auth() (transport.AuthMethod, error) {
 
 	envUsername := os.Getenv("DGIT_USERNAME")
 	if envUsername != "" {
+		log.Warningf("[DEPRECATION] - DGIT_USERNAME is deprecated, please use DG_USERNAME")
+		username = envUsername
+	}
+	envUsername = os.Getenv("DG_USERNAME")
+	if envUsername != "" {
 		username = envUsername
 	}
 
@@ -325,19 +330,24 @@ func (r *Runner) auth() (transport.AuthMethod, error) {
 }
 
 func (r *Runner) authFromEnv() (transport.AuthMethod, error) {
-	privateKeyEnv, ok := os.LookupEnv("DGIT_PRIVATE_KEY")
+	privateKeyEnv, ok := os.LookupEnv("DG_PRIVATE_KEY")
 	if !ok {
-		return nil, nil
+		// TODO: remove backward compatible usage
+		privateKeyEnv, ok = os.LookupEnv("DGIT_PRIVATE_KEY")
+		if !ok {
+			log.Warningf("[DEPRECATION] - DGIT_PRIVATE_KEY is deprecated, please use DG_PRIVATE_KEY")
+			return nil, nil
+		}
 	}
 
 	privateKeyBytes, err := hexutil.Decode(privateKeyEnv)
 	if err != nil {
-		return nil, fmt.Errorf("error hex decoding DGIT_PRIVATE_KEY: %v", err)
+		return nil, fmt.Errorf("error hex decoding DG_PRIVATE_KEY: %v", err)
 	}
 
 	privateKey, err := crypto.ToECDSA(privateKeyBytes)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling DGIT_PRIVATE_KEY into ECDSA private key: %v", err)
+		return nil, fmt.Errorf("error unmarshalling DG_PRIVATE_KEY into ECDSA private key: %v", err)
 	}
 
 	return dgit.NewPrivateKeyAuth(privateKey), nil

--- a/remotehelper/runner_test.go
+++ b/remotehelper/runner_test.go
@@ -32,7 +32,7 @@ func TestRunnerIntegration(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err := os.Setenv("DGIT_OBJ_STORAGE", "chaintree")
+	err := os.Setenv("DG_OBJ_STORAGE", "chaintree")
 	require.Nil(t, err)
 
 	// Just generating a random username
@@ -40,14 +40,14 @@ func TestRunnerIntegration(t *testing.T) {
 	require.Nil(t, err)
 	username := strings.ToLower(crypto.PubkeyToAddress(key.PublicKey).String()[20:])
 
-	err = os.Setenv("DGIT_USERNAME", username)
+	err = os.Setenv("DG_USERNAME", username)
 	require.Nil(t, err)
 
 	client, err := dgit.NewLocalClient(ctx)
 	require.Nil(t, err)
 	client.RegisterAsDefault()
 
-	logLevelStr, ok := os.LookupEnv("DGIT_LOG_LEVEL")
+	logLevelStr, ok := os.LookupEnv("DG_LOG_LEVEL")
 	if ok {
 		require.Nil(t, logging.SetLogLevelRegex("decentragit.*", strings.ToUpper(logLevelStr)))
 	}
@@ -85,10 +85,9 @@ func TestRunnerIntegration(t *testing.T) {
 	auth := dgit.NewPrivateKeyAuth(pkey)
 
 	_, err = usertree.Create(ctx, &usertree.Options{
-		Name:      username,
-		Tupelo:    client.Tupelo,
-		NodeStore: client.Nodestore,
-		Owners:    []string{auth.String()},
+		Name:   username,
+		Tupelo: client.Tupelo,
+		Owners: []string{auth.String()},
 	})
 	require.Nil(t, err)
 

--- a/storage/chaintree/storage.go
+++ b/storage/chaintree/storage.go
@@ -16,7 +16,7 @@ import (
 	"github.com/go-git/go-git/v5/storage/memory"
 )
 
-var RepoConfigPath = []string{"tree", "data", "dgit", "config"}
+var RepoConfigPath = []string{"tree", "data", "config"}
 
 const defaultStorageProvider = "chaintree"
 

--- a/transport/dgit/repo.go
+++ b/transport/dgit/repo.go
@@ -136,6 +136,11 @@ func (r *Repo) Username() (string, error) {
 
 	envUsername := os.Getenv("DGIT_USERNAME")
 	if envUsername != "" {
+		log.Warningf("[DEPRECATION] - DGIT_USERNAME is deprecated, please use DG_USERNAME")
+		username = envUsername
+	}
+	envUsername = os.Getenv("DG_USERNAME")
+	if envUsername != "" {
 		username = envUsername
 	}
 

--- a/tupelo/repotree/repotree.go
+++ b/tupelo/repotree/repotree.go
@@ -26,7 +26,7 @@ var log = logging.Logger("decentragit.repotree")
 
 var ErrNotFound = tree.ErrNotFound
 
-var teamsMapPath = []string{"dgit", "teams"}
+var teamsMapPath = []string{"teams"}
 
 type Options struct {
 	Name              string
@@ -104,6 +104,10 @@ func Create(ctx context.Context, opts *Options, ownerKey *ecdsa.PrivateKey) (*Re
 	}
 
 	if storage, found := os.LookupEnv("DGIT_OBJ_STORAGE"); found {
+		log.Warningf("[DEPRECATION] - DGIT_OBJ_STORAGE is deprecated, please use DG_OBJ_STORAGE")
+		opts.ObjectStorageType = storage
+	}
+	if storage, found := os.LookupEnv("DG_OBJ_STORAGE"); found {
 		opts.ObjectStorageType = storage
 	}
 	if opts.ObjectStorageType == "" {
@@ -111,7 +115,7 @@ func Create(ctx context.Context, opts *Options, ownerKey *ecdsa.PrivateKey) (*Re
 	}
 
 	config := map[string]map[string]string{"objectStorage": {"type": opts.ObjectStorageType}}
-	configTxn, err := chaintree.NewSetDataTransaction("dgit/config", config)
+	configTxn, err := chaintree.NewSetDataTransaction("config", config)
 	if err != nil {
 		return nil, err
 	}

--- a/tupelo/teamtree/teamtree.go
+++ b/tupelo/teamtree/teamtree.go
@@ -17,7 +17,7 @@ var log = logging.Logger("decentragit.teamtree")
 
 var ErrNotFound = tree.ErrNotFound
 
-var membersPath = []string{"dgit", "members"}
+var membersPath = []string{"members"}
 
 type Options struct {
 	Name    string

--- a/tupelo/tree/tree.go
+++ b/tupelo/tree/tree.go
@@ -55,16 +55,16 @@ func Find(ctx context.Context, tupelo *client.Client, did string) (*Tree, error)
 		return nil, ErrNotFound
 	}
 
-	name, _, err := chainTree.ChainTree.Dag.Resolve(ctx, []string{"tree", "data", "dgit", "name"})
+	name, _, err := chainTree.ChainTree.Dag.Resolve(ctx, []string{"tree", "data", "name"})
 	if err != nil {
 		return nil, err
 	}
 	if name == nil {
-		return nil, fmt.Errorf("Invalid dgit ChainTree, must have dgit/name set")
+		return nil, fmt.Errorf("Invalid dgit ChainTree, must have .name set")
 	}
 	nameStr, ok := name.(string)
 	if !ok {
-		return nil, fmt.Errorf("Invalid dgit ChainTree, dgit/name must be a string, got %T", name)
+		return nil, fmt.Errorf("Invalid dgit ChainTree, .name must be a string, got %T", name)
 	}
 
 	return New(nameStr, chainTree, tupelo), nil
@@ -104,12 +104,12 @@ func Create(ctx context.Context, opts *Options) (*Tree, error) {
 		return nil, err
 	}
 
-	nameTxn, err := chaintree.NewSetDataTransaction("dgit/name", opts.Name)
+	nameTxn, err := chaintree.NewSetDataTransaction("name", opts.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	creationTimestampTxn, err := chaintree.NewSetDataTransaction("dgit/createdAt", time.Now().Unix())
+	creationTimestampTxn, err := chaintree.NewSetDataTransaction("createdAt", time.Now().Unix())
 	if err != nil {
 		return nil, err
 	}

--- a/tupelo/usertree/usertree.go
+++ b/tupelo/usertree/usertree.go
@@ -21,11 +21,11 @@ type UserTree struct {
 
 var log = logging.Logger("decentragit.usertree")
 
-const userSalt = "dgit-user-v0"
+const userSalt = "decentragit-user-v0"
 
 var namedTreeGen *namedtree.Generator
 
-var reposMapPath = []string{"dgit", "repos"}
+var reposMapPath = []string{"repos"}
 
 var ErrNotFound = tree.ErrNotFound
 


### PR DESCRIPTION
just a few more dgit => dg/decentragit renames:
- removes `dgit` prefix inside `tree/data`
- changes env vars to be `DG_`, with support for the old `DGIT_` (happy to take that out though)
- changes keychain keys to be `decentragit.` --- this release invalidates old ChainTrees anyways, so might as well just use a new namespace. Also took out the default key migration function because those keys will be useless now