### PR TITLE
ensure user exists before adding to team

### DIFF
--- a/transport/dgit/client.go
+++ b/transport/dgit/client.go
@@ -128,12 +128,15 @@ func (c *Client) AddRepoCollaborator(ctx context.Context, repo *Repo, collaborat
 
 	members := make(teamtree.Members, len(collaborators))
 	for i, username := range collaborators {
-		did, err := usertree.Did(username)
+		user, err := usertree.Find(ctx, username, c.Tupelo)
+		if err == usertree.ErrNotFound {
+			return fmt.Errorf("User %s not found", username)
+		}
 		if err != nil {
 			return err
 		}
 
-		members[i] = teamtree.NewMember(did, username)
+		members[i] = teamtree.NewMember(user.Did(), username)
 	}
 
 	return team.AddMembers(ctx, pkAuth.Key(), members)


### PR DESCRIPTION
this is a fix ahead of https://github.com/quorumcontrol/tupelo/pull/474 to ensure `team add` checks that a user exists, else on future pushes to that repo tree, it will fail looking for the not-yet-existing users chaintree